### PR TITLE
feat: CCP-4728-improve attachment validation error messages

### DIFF
--- a/backend/src/api/notify/notify.controller.spec.ts
+++ b/backend/src/api/notify/notify.controller.spec.ts
@@ -32,6 +32,7 @@ import { AttachmentValidationService } from './services/attachment-validation.se
 import { FeatureFlagService } from '../../api/feature-flag/feature-flag.service'
 import { TenantsService } from '../../api/admin/tenants/tenants.service'
 import { WebhookService } from '../../api/webhook/webhook.service'
+import { ValidationExceptionFilter } from '../../common/filters/validation.filter'
 
 // Mock AuthGuard to bypass authentication in tests
 const mockAuthGuard: CanActivate = {
@@ -138,12 +139,12 @@ describe('Notify Controllers', () => {
     app = module.createNestApplication()
     app.useGlobalPipes(
       new ValidationPipe({
-        errorHttpStatusCode: 422,
         whitelist: true,
         forbidNonWhitelisted: true,
         transform: true,
       }),
     )
+    app.useGlobalFilters(new ValidationExceptionFilter())
     app.enableVersioning({
       type: VersioningType.URI,
       prefix: 'api/v',
@@ -271,6 +272,76 @@ describe('Notify Controllers', () => {
         expect(mockNotificationService.create).not.toHaveBeenCalled()
         expect(mockNotificationService.validateBusinessRules).not.toHaveBeenCalled()
         expect(mockAttachmentProcessingService.processAttachments).not.toHaveBeenCalled()
+      })
+
+      it('should return a clear DTO error when attachment content is missing', async () => {
+        await request(app.getHttpServer())
+          .post('/api/v1/notifysimple')
+          .send({
+            email: {
+              recipients: { to: ['test@example.com'] },
+              content: { subject: 'Test', body: 'Hello' },
+              attachments: [
+                {
+                  filename: 'hello.txt',
+                  mimeType: 'text/plain',
+                },
+              ],
+            },
+          })
+          .expect(400)
+          .expect((res) => {
+            expect(res.body).toEqual({
+              statusCode: 400,
+              message: 'Validation failed',
+              errors: ['Attachment content is required and must be a base64-encoded string.'],
+              fieldErrors: {
+                'email.attachments.0.content':
+                  'Attachment content is required and must be a base64-encoded string.',
+              },
+            })
+          })
+
+        expect(mockAttachmentValidationService.validateAttachments).not.toHaveBeenCalled()
+        expect(mockNotificationService.create).not.toHaveBeenCalled()
+      })
+
+      it("should map the legacy attachment 'data' field to a clearer validation error", async () => {
+        await request(app.getHttpServer())
+          .post('/api/v1/notifysimple')
+          .send({
+            email: {
+              recipients: { to: ['test@example.com'] },
+              content: { subject: 'Test', body: 'Hello' },
+              attachments: [
+                {
+                  filename: 'hello.txt',
+                  mimeType: 'text/plain',
+                  data: 'SGVsbG8=',
+                },
+              ],
+            },
+          })
+          .expect(400)
+          .expect((res) => {
+            expect(res.body).toEqual({
+              statusCode: 400,
+              message: 'Validation failed',
+              errors: [
+                "The attachment field 'data' is not supported. Use 'content' instead.",
+                'Attachment content is required and must be a base64-encoded string.',
+              ],
+              fieldErrors: {
+                'email.attachments.0.data':
+                  "The attachment field 'data' is not supported. Use 'content' instead.",
+                'email.attachments.0.content':
+                  'Attachment content is required and must be a base64-encoded string.',
+              },
+            })
+          })
+
+        expect(mockAttachmentValidationService.validateAttachments).not.toHaveBeenCalled()
+        expect(mockNotificationService.create).not.toHaveBeenCalled()
       })
 
       it('should process attachments before persisting and remove raw data from the stored payload', async () => {

--- a/backend/src/api/notify/schemas/notify-attachment.ts
+++ b/backend/src/api/notify/schemas/notify-attachment.ts
@@ -1,16 +1,19 @@
-import { IsString } from 'class-validator'
+import { IsString, MinLength } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 
 export class NotifyAttachment {
   @ApiProperty()
-  @IsString()
+  @IsString({ message: 'Attachment filename is required and must be a string.' })
+  @MinLength(1, { message: 'Attachment filename is required and must be a string.' })
   filename: string
 
   @ApiProperty()
-  @IsString()
+  @IsString({ message: 'Attachment MIME type is required and must be a string.' })
+  @MinLength(1, { message: 'Attachment MIME type is required and must be a string.' })
   mimeType: string
 
   @ApiProperty()
-  @IsString()
+  @IsString({ message: 'Attachment content is required and must be a base64-encoded string.' })
+  @MinLength(1, { message: 'Attachment content is required and must be a base64-encoded string.' })
   content: string
 }

--- a/backend/src/api/notify/services/attachment-validation.service.spec.ts
+++ b/backend/src/api/notify/services/attachment-validation.service.spec.ts
@@ -35,6 +35,15 @@ function makeRequest(overrides: Partial<NotifySimpleRequest> = {}): NotifySimple
   } as NotifySimpleRequest
 }
 
+async function captureError(promise: Promise<unknown>) {
+  try {
+    await promise
+    throw new Error('Expected promise to reject')
+  } catch (error) {
+    return error as BadRequestException | PayloadTooLargeException
+  }
+}
+
 describe('AttachmentValidationService', () => {
   let service: AttachmentValidationService
   let mimeTypeRepository: Repository<MimeTypeCode>
@@ -137,7 +146,11 @@ describe('AttachmentValidationService', () => {
       } as any,
     })
 
-    await expect(service.validateAttachments(request)).rejects.toThrow(BadRequestException)
+    const error = await captureError(service.validateAttachments(request))
+
+    expect(error).toBeInstanceOf(BadRequestException)
+    expect(error.getStatus()).toBe(400)
+    expect(error.message).toBe("Attachment MIME type 'application/x-msdownload' is not allowed.")
   })
 
   it('should throw BadRequestException for invalid filename with path traversal', async () => {
@@ -153,7 +166,13 @@ describe('AttachmentValidationService', () => {
       } as any,
     })
 
-    await expect(service.validateAttachments(request)).rejects.toThrow(BadRequestException)
+    const error = await captureError(service.validateAttachments(request))
+
+    expect(error).toBeInstanceOf(BadRequestException)
+    expect(error.getStatus()).toBe(400)
+    expect(error.message).toBe(
+      "Attachment filename '../secret.txt' is invalid. Use a filename without directory paths.",
+    )
   })
 
   it('should throw BadRequestException for invalid filename with slash or backslash', async () => {
@@ -169,7 +188,13 @@ describe('AttachmentValidationService', () => {
       } as any,
     })
 
-    await expect(service.validateAttachments(request)).rejects.toThrow(BadRequestException)
+    const error = await captureError(service.validateAttachments(request))
+
+    expect(error).toBeInstanceOf(BadRequestException)
+    expect(error.getStatus()).toBe(400)
+    expect(error.message).toBe(
+      "Attachment filename 'folder\\hello.txt' is invalid. Use a filename without directory paths.",
+    )
   })
 
   it('should throw BadRequestException for invalid base64', async () => {
@@ -185,7 +210,11 @@ describe('AttachmentValidationService', () => {
       } as any,
     })
 
-    await expect(service.validateAttachments(request)).rejects.toThrow(BadRequestException)
+    const error = await captureError(service.validateAttachments(request))
+
+    expect(error).toBeInstanceOf(BadRequestException)
+    expect(error.getStatus()).toBe(400)
+    expect(error.message).toBe("Attachment 'hello.txt' content is not valid base64.")
   })
 
   it('should throw PayloadTooLargeException for an individual attachment over the configured limit', async () => {
@@ -202,11 +231,15 @@ describe('AttachmentValidationService', () => {
       } as any,
     })
 
-    await expect(service.validateAttachments(request)).rejects.toThrow(PayloadTooLargeException)
+    const error = await captureError(service.validateAttachments(request))
+
+    expect(error).toBeInstanceOf(PayloadTooLargeException)
+    expect(error.getStatus()).toBe(413)
+    expect(error.message).toBe("Attachment 'large.txt' exceeds the maximum allowed size of 5 MB.")
   })
 
   it('should throw PayloadTooLargeException when total attachments exceed the configured limit', async () => {
-    const largeBuffer = Buffer.alloc(13 * 1024 * 1024, 'a')
+    const largeBuffer = Buffer.alloc(Math.floor(4.5 * 1024 * 1024), 'a')
     const request = makeRequest({
       email: {
         attachments: [
@@ -224,11 +257,37 @@ describe('AttachmentValidationService', () => {
             mimeType: 'text/plain',
             content: largeBuffer.toString('base64'),
           },
+          {
+            filename: 'large-three.txt',
+            mimeType: 'text/plain',
+            content: largeBuffer.toString('base64'),
+          },
+          {
+            filename: 'large-four.txt',
+            mimeType: 'text/plain',
+            content: largeBuffer.toString('base64'),
+          },
+          {
+            filename: 'large-five.txt',
+            mimeType: 'text/plain',
+            content: largeBuffer.toString('base64'),
+          },
+          {
+            filename: 'large-six.txt',
+            mimeType: 'text/plain',
+            content: largeBuffer.toString('base64'),
+          },
         ],
       } as any,
     })
 
-    await expect(service.validateAttachments(request)).rejects.toThrow(PayloadTooLargeException)
+    const error = await captureError(service.validateAttachments(request))
+
+    expect(error).toBeInstanceOf(PayloadTooLargeException)
+    expect(error.getStatus()).toBe(413)
+    expect(error.message).toBe(
+      'Combined attachment size exceeds the maximum allowed size of 25 MB.',
+    )
   })
 
   it('should throw BadRequestException when filename exceeds the configured limit', async () => {
@@ -244,6 +303,12 @@ describe('AttachmentValidationService', () => {
       } as any,
     })
 
-    await expect(service.validateAttachments(request)).rejects.toThrow(BadRequestException)
+    const error = await captureError(service.validateAttachments(request))
+
+    expect(error).toBeInstanceOf(BadRequestException)
+    expect(error.getStatus()).toBe(400)
+    expect(error.message).toBe(
+      'Attachment filename exceeds the maximum allowed length of 255 characters.',
+    )
   })
 })

--- a/backend/src/api/notify/services/attachment-validation.service.ts
+++ b/backend/src/api/notify/services/attachment-validation.service.ts
@@ -13,17 +13,15 @@ import { NotifyAttachment } from '../schemas/notify-attachment'
 import { MimeTypeCode } from '../../notification/entities/mime-type-code.entity'
 import { NotifyConfiguration } from '../../notification/entities/configuration.entity'
 
-type AttachmentChannel = 'email' | 'sms' | 'msgApp'
-
 interface AttachmentConfig {
+  maxAttachmentSizeMb: number
+  maxRequestSizeMb: number
   maxAttachmentSizeBytes: number
   maxRequestSizeBytes: number
   maxFilenameLength: number
 }
 
 interface CollectedAttachment {
-  channel: AttachmentChannel
-  index: number
   attachment: NotifyAttachment
 }
 
@@ -54,22 +52,22 @@ export class AttachmentValidationService {
     for (const entry of attachments) {
       const { attachment } = entry
 
-      this.validateMimeType(entry, attachment.mimeType, allowedMimeTypes)
-      this.validateFilename(entry, attachment.filename, config.maxFilenameLength)
+      this.validateMimeType(attachment.mimeType, allowedMimeTypes)
+      this.validateFilename(attachment.filename, config.maxFilenameLength)
 
       const decoded = this.decodeBase64(entry, attachment.content)
       const decodedBytes = decoded.byteLength
 
       if (decodedBytes > config.maxAttachmentSizeBytes) {
         throw new PayloadTooLargeException(
-          `Attachment "${attachment.filename}" exceeds the maximum allowed size of ${config.maxAttachmentSizeBytes} bytes`,
+          `Attachment '${attachment.filename}' exceeds the maximum allowed size of ${config.maxAttachmentSizeMb} MB.`,
         )
       }
 
       totalDecodedBytes += decodedBytes
       if (totalDecodedBytes > config.maxRequestSizeBytes) {
         throw new PayloadTooLargeException(
-          `Total attachment size exceeds the maximum allowed size of ${config.maxRequestSizeBytes} bytes`,
+          `Combined attachment size exceeds the maximum allowed size of ${config.maxRequestSizeMb} MB.`,
         )
       }
     }
@@ -77,15 +75,15 @@ export class AttachmentValidationService {
 
   private collectAttachments(request: NotifySimpleRequest): CollectedAttachment[] {
     const collected: CollectedAttachment[] = []
-    const channels: Array<{ channel: AttachmentChannel; attachments?: NotifyAttachment[] }> = [
-      { channel: 'email', attachments: request.email?.attachments },
-      { channel: 'sms', attachments: request.sms?.attachments },
-      { channel: 'msgApp', attachments: request.msgApp?.attachments },
+    const channels: Array<{ attachments?: NotifyAttachment[] }> = [
+      { attachments: request.email?.attachments },
+      { attachments: request.sms?.attachments },
+      { attachments: request.msgApp?.attachments },
     ]
 
-    for (const { channel, attachments } of channels) {
-      attachments?.forEach((attachment, index) => {
-        collected.push({ channel, index, attachment })
+    for (const { attachments } of channels) {
+      attachments?.forEach((attachment) => {
+        collected.push({ attachment })
       })
     }
 
@@ -122,6 +120,8 @@ export class AttachmentValidationService {
     const maxFilenameLength = this.readNumericConfig(configMap, 'attachment_max_filename_length')
 
     return {
+      maxAttachmentSizeMb,
+      maxRequestSizeMb,
       maxAttachmentSizeBytes: maxAttachmentSizeMb * 1024 * 1024,
       maxRequestSizeBytes: maxRequestSizeMb * 1024 * 1024,
       maxFilenameLength,
@@ -143,56 +143,44 @@ export class AttachmentValidationService {
     return value
   }
 
-  private validateMimeType(
-    entry: CollectedAttachment,
-    mimeType: string,
-    allowedMimeTypes: Set<string>,
-  ): void {
+  private validateMimeType(mimeType: string, allowedMimeTypes: Set<string>): void {
     if (!allowedMimeTypes.has(mimeType)) {
-      throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} has disallowed MIME type "${mimeType}"`,
-      )
+      throw new BadRequestException(`Attachment MIME type '${mimeType}' is not allowed.`)
     }
   }
 
-  private validateFilename(
-    entry: CollectedAttachment,
-    filename: string,
-    maxFilenameLength: number,
-  ): void {
+  private validateFilename(filename: string, maxFilenameLength: number): void {
     if (!filename.trim()) {
-      throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} must include a valid filename`,
-      )
+      throw new BadRequestException('Attachment filename is required and must be a string.')
     }
 
     if (filename.length > maxFilenameLength) {
       throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} filename exceeds the maximum length of ${maxFilenameLength}`,
+        `Attachment filename exceeds the maximum allowed length of ${maxFilenameLength} characters.`,
       )
     }
 
     if (path.posix.isAbsolute(filename) || path.win32.isAbsolute(filename)) {
       throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} filename must not be an absolute path`,
+        `Attachment filename '${filename}' is invalid. Use a filename without directory paths.`,
       )
     }
 
     if (filename.includes('/') || filename.includes('\\')) {
       throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} filename must not contain path separators`,
+        `Attachment filename '${filename}' is invalid. Use a filename without directory paths.`,
       )
     }
 
     if (filename.includes('..')) {
       throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} filename must not contain path traversal sequences`,
+        `Attachment filename '${filename}' is invalid. Use a filename without directory paths.`,
       )
     }
 
     if (filename !== path.posix.basename(filename) || filename !== path.win32.basename(filename)) {
       throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} filename is invalid`,
+        `Attachment filename '${filename}' is invalid. Use a filename without directory paths.`,
       )
     }
   }
@@ -202,21 +190,17 @@ export class AttachmentValidationService {
 
     if (data.length % 4 !== 0 || !base64Pattern.test(data)) {
       throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} contains invalid base64 data`,
+        `Attachment '${entry.attachment.filename}' content is not valid base64.`,
       )
     }
 
     const decoded = Buffer.from(data, 'base64')
     if (decoded.toString('base64') !== data) {
       throw new BadRequestException(
-        `Attachment ${this.describeAttachment(entry)} contains invalid base64 data`,
+        `Attachment '${entry.attachment.filename}' content is not valid base64.`,
       )
     }
 
     return decoded
-  }
-
-  private describeAttachment(entry: CollectedAttachment): string {
-    return `"${entry.channel}" attachment at index ${entry.index}`
   }
 }

--- a/backend/src/common/filters/validation.filter.ts
+++ b/backend/src/common/filters/validation.filter.ts
@@ -5,6 +5,11 @@ interface ValidationError {
   [key: string]: string | string[]
 }
 
+interface FormattedValidationMessage {
+  field: string
+  message: string
+}
+
 /**
  * Custom exception filter for better validation error formatting
  * Converts validation error arrays into more readable field-by-field format
@@ -22,24 +27,25 @@ export class ValidationExceptionFilter implements ExceptionFilter {
     // If it's a validation error, reformat it
     if (status === 400 && exceptionResponse.message && Array.isArray(exceptionResponse.message)) {
       const fieldErrors: ValidationError = {}
+      const formattedErrors = exceptionResponse.message
+        .map((message: string) => this.formatValidationMessage(message))
+        .filter(
+          (item, index, items) =>
+            items.findIndex(
+              (candidate) => candidate.field === item.field && candidate.message === item.message,
+            ) === index,
+        )
 
       // Group errors by field
-      for (const message of exceptionResponse.message) {
-        // Extract field name from validation message
-        // Messages are typically like "field_name error description"
-        const match = message.match(/^(\w+)\s+(.+)$/)
-        if (match) {
-          const field = match[1]
-          const error = match[2]
-          if (fieldErrors[field]) {
-            if (Array.isArray(fieldErrors[field])) {
-              ;(fieldErrors[field] as string[]).push(error)
-            } else {
-              fieldErrors[field] = [fieldErrors[field] as string, error]
-            }
+      for (const { field, message } of formattedErrors) {
+        if (fieldErrors[field]) {
+          if (Array.isArray(fieldErrors[field])) {
+            ;(fieldErrors[field] as string[]).push(message)
           } else {
-            fieldErrors[field] = error
+            fieldErrors[field] = [fieldErrors[field] as string, message]
           }
+        } else {
+          fieldErrors[field] = message
         }
       }
 
@@ -48,12 +54,49 @@ export class ValidationExceptionFilter implements ExceptionFilter {
       response.status(status).json({
         statusCode: status,
         message: 'Validation failed',
-        errors: exceptionResponse.message,
+        errors: formattedErrors.map((item) => item.message),
         fieldErrors,
       })
     } else {
       // Default behavior for non-validation errors
       response.status(status).json(exceptionResponse)
+    }
+  }
+
+  private formatValidationMessage(message: string): FormattedValidationMessage {
+    const dataFieldMatch = message.match(/^(.*?attachments\.\d+)\.property data should not exist$/)
+    if (dataFieldMatch) {
+      return {
+        field: `${dataFieldMatch[1]}.data`,
+        message: "The attachment field 'data' is not supported. Use 'content' instead.",
+      }
+    }
+
+    const attachmentFieldMatch = message.match(
+      /^(.*?attachments\.\d+)\.Attachment (filename|MIME type|content) (.+)$/,
+    )
+    if (attachmentFieldMatch) {
+      const [, prefix, fieldLabel, suffix] = attachmentFieldMatch
+      const fieldKey =
+        fieldLabel === 'filename' ? 'filename' : fieldLabel === 'MIME type' ? 'mimeType' : 'content'
+
+      return {
+        field: `${prefix}.${fieldKey}`,
+        message: `Attachment ${fieldLabel} ${suffix}`,
+      }
+    }
+
+    const match = message.match(/^([^\s]+)\s+(.+)$/)
+    if (match) {
+      return {
+        field: match[1],
+        message: match[2],
+      }
+    }
+
+    return {
+      field: 'general',
+      message,
     }
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
 improves attachment validation responses for the Notify API so callers receive clearer, actionable error messages while preserving the existing HTTP status behavior.

What Changed
Updated attachment DTO validation messages in backend/src/api/notify/schemas/notify-attachment.ts
Updated attachment business-validation messages in backend/src/api/notify/services/attachment-validation.service.ts
Enhanced centralized validation formatting in backend/src/common/filters/validation.filter.ts
Added focused handling for the legacy attachment field data so clients are told to use content instead
Added/updated tests covering DTO and business-validation attachment failures

Behavior
The API now returns friendlier messages for attachment errors such as:

unsupported legacy field data
missing attachment content
invalid base64 content
unsupported MIME type
unsafe filenames
filename length violations
single attachment size limit exceeded
combined attachment size limit exceeded
Status Codes
This PR preserves status code behavior:

400 for invalid filename, MIME type, missing content, invalid base64
413 for single-file and combined attachment size limits
500 only for unexpected internal failures

Fixes # 4728

## Type of change

<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-116.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-116.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)