### PR TITLE
feat: implement path-based routing for PR gateway deployments

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -77,12 +77,46 @@ jobs:
       cancel-in-progress: false # Queue instead of canceling
     steps:
       - uses: actions/checkout@v4
-      - name: Generate DEV-only gateway configuration
+      - name: Generate DEV gateway configuration
         run: |
           chmod +x api-gateway/scripts/generate-gateway-for-stage.sh
-          # Generate DEV only - this will remove TEST/PROD routes until they are re-approved
+          # Generate DEV - this will remove TEST/PROD routes until they are re-approved
           api-gateway/scripts/generate-gateway-for-stage.sh dev
-      - name: Apply DEV gateway config (removes TEST/PROD temporarily)
+
+      - name: Add open PR routes (path-based routing)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Find all open PRs to preserve their routes (path-based routing on same tag as DEV)
+          OPEN_PRS=$(gh pr list --state open --json number --jq '.[].number')
+
+          if [ -z "$OPEN_PRS" ]; then
+            echo "No open PRs found - applying DEV config only"
+            exit 0
+          fi
+
+          echo "Found open PRs: $OPEN_PRS"
+          echo "Generating PR configs to preserve routes alongside DEV..."
+
+          # Start with DEV config
+          cp api-gateway/generated/gw-active-services.yaml api-gateway/generated/gw-dev-with-prs.yaml
+
+          # Generate and append each open PR config
+          for PR_NUM in $OPEN_PRS; do
+            echo "Adding PR-${PR_NUM} routes..."
+            chmod +x api-gateway/scripts/generate-gateway-config.sh
+            api-gateway/scripts/generate-gateway-config.sh pr common-notify-${PR_NUM}
+
+            # Append PR config to combined file
+            echo "---" >> api-gateway/generated/gw-dev-with-prs.yaml
+            cat api-gateway/generated/gw-routes-pr.yaml >> api-gateway/generated/gw-dev-with-prs.yaml
+          done
+
+          # Use combined file for apply
+          mv api-gateway/generated/gw-dev-with-prs.yaml api-gateway/generated/gw-active-services.yaml
+          echo "✅ Combined DEV + ${OPEN_PRS} PR route(s)"
+
+      - name: Apply DEV gateway config (with open PRs)
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
@@ -92,8 +126,9 @@ jobs:
           CLIENT_SECRET=$(echo "$GWA_ACCT" | jq -r '.client_secret')
           gwa login --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET"
           gwa config set gateway gw-fe8c5
-          # Apply DEV only - TEST and PROD routes will be removed until re-approved
-          echo "⚠️  Applying DEV config only - TEST and PROD routes will be temporarily removed"
+          # Apply DEV + open PRs - TEST and PROD routes will be removed until re-approved
+          # All share tag ns.gw-fe8c5.dev but use path-based routing for isolation
+          echo "✅ Applying DEV config (with open PR routes) - TEST and PROD routes will be temporarily removed"
           gwa apply -i api-gateway/generated/gw-active-services.yaml
 
   deploy-dev:

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -46,15 +46,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate gateway config (dev+test+prod only)
+      - name: Generate gateway config (dev+test+prod + other open PRs)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x api-gateway/scripts/generate-gateway-for-stage.sh
-          # Generate combined services file with dev+test+prod (excludes PR)
-          # Note: This restores all three environments. If main is mid-deployment,
-          # the next deployment step will correct the state.
+          # Generate combined services file with dev+test+prod
           api-gateway/scripts/generate-gateway-for-stage.sh prod
 
-      - name: Remove PR service by applying permanent services
+          # Find OTHER open PRs (exclude the one being closed)
+          CURRENT_PR=${{ github.event.number }}
+          OTHER_OPEN_PRS=$(gh pr list --state open --json number --jq '.[] | select(.number != '$CURRENT_PR') | .number')
+
+          if [ -z "$OTHER_OPEN_PRS" ]; then
+            echo "No other open PRs - applying DEV+TEST+PROD only"
+            exit 0
+          fi
+
+          echo "Found other open PRs: $OTHER_OPEN_PRS"
+          echo "Preserving their routes alongside DEV+TEST+PROD..."
+
+          # Append each OTHER open PR config
+          for PR_NUM in $OTHER_OPEN_PRS; do
+            echo "Adding PR-${PR_NUM} routes..."
+            chmod +x api-gateway/scripts/generate-gateway-config.sh
+            api-gateway/scripts/generate-gateway-config.sh pr common-notify-${PR_NUM}
+
+            # Append PR config
+            echo "---" >> api-gateway/generated/gw-active-services.yaml
+            cat api-gateway/generated/gw-routes-pr.yaml >> api-gateway/generated/gw-active-services.yaml
+          done
+
+          echo "✅ Combined DEV+TEST+PROD + ${OTHER_OPEN_PRS} open PR(s)"
+
+      - name: Remove this PR's routes (preserve other open PRs)
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
@@ -70,16 +95,17 @@ jobs:
           # Set gateway context
           gwa config set gateway gw-fe8c5
 
-          # Apply permanent services (dev+test+prod) - this will remove PR service
-          echo "✅ Removing PR service by applying DEV+TEST+PROD config"
+          # Apply permanent services + other open PRs
+          # This removes the CLOSED PR but preserves other open PR routes
+          echo "✅ Removing PR-${{ github.event.number }} routes (preserving other open PRs)"
           gwa apply -i api-gateway/generated/gw-active-services.yaml
 
       - name: Wait for PR service deletion
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
-          # Define PR service name
-          PR_SERVICE_NAME="nr-notify-pr-${{ github.event.number }}"
+          # Define PR service name (matches template: ${GATEWAY_SERVICE_NAME})
+          PR_SERVICE_NAME="gw-fe8c5-notify-pr-${{ github.event.number }}"
 
           echo "Waiting for service '$PR_SERVICE_NAME' to be deleted..."
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,42 +64,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch current DEV config from main branch
-        run: |
-          # Save current PR branch configs
-          mkdir -p /tmp/pr-configs
-          cp -r api-gateway /tmp/pr-configs/
-
-          # Fetch main branch to get DEV config
-          git fetch origin main
-          git checkout origin/main -- api-gateway/
-
-          # Generate DEV config only from main branch
-          # DEV and PR share the same gateway tag (ns.gw-fe8c5.dev) so they must be published together
-          # TEST and PROD have separate tags and remain unchanged
-          chmod +x api-gateway/scripts/generate-gateway-config.sh
-          api-gateway/scripts/generate-gateway-config.sh dev
-
-          # Save DEV config
-          cp api-gateway/generated/gw-routes-dev.yaml /tmp/dev-config.yaml
-
       - name: Generate PR config from PR branch
         run: |
-          # Restore PR branch configs
-          rm -rf api-gateway
-          cp -r /tmp/pr-configs/api-gateway .
-
           # Generate PR config only from PR branch code
+          # PR shares tag ns.gw-fe8c5.dev with DEV (path-based routing)
+          # DEV service already exists from merge workflow - only apply PR service
           chmod +x api-gateway/scripts/generate-gateway-config.sh
           api-gateway/scripts/generate-gateway-config.sh pr common-notify-${{ github.event.number }}
 
-          # Combine: DEV config (main) + PR config (PR branch)
-          # Both share the same gateway tag (ns.gw-fe8c5.dev) for path-based routing
-          cp /tmp/dev-config.yaml api-gateway/generated/gw-combined-dev-pr.yaml
-          echo "---" >> api-gateway/generated/gw-combined-dev-pr.yaml
-          cat api-gateway/generated/gw-routes-pr.yaml >> api-gateway/generated/gw-combined-dev-pr.yaml
-
-      - name: Apply DEV+PR config (path-based routing)
+      - name: Apply PR config (path-based routing)
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
@@ -115,27 +88,30 @@ jobs:
           # Set gateway context
           gwa config set gateway gw-fe8c5
 
-          # Publish: DEV config (from main) + PR config (from PR branch)
-          # Both share tag ns.gw-fe8c5.dev for path-based routing
-          # TEST and PROD configs remain unchanged (separate tags, already published)
-          echo "✅ Publishing DEV+PR config (path-based routing on shared tag ns.gw-fe8c5.dev)"
+          # Apply PR config only
+          # PR shares tag ns.gw-fe8c5.dev with DEV for path-based routing
+          # DEV service already exists from merge workflow
+          # This adds PR routes without affecting DEV routes (different paths)
+          echo "✅ Applying PR config (path-based routing /pr-${{ github.event.number }}/)"
 
-          # Use publish-gateway with --qualifier dev (both DEV and PR share this qualifier)
-          # This properly handles updating existing services instead of trying to create them
-          if ! gwa publish-gateway api-gateway/generated/gw-combined-dev-pr.yaml --qualifier dev 2>&1 | tee /tmp/gwa-output.txt; then
-            echo "❌ gwa publish-gateway command failed"
-            cat /tmp/gwa-output.txt
-            exit 1
+          gwa apply -i api-gateway/generated/gw-routes-pr.yaml 2>&1 | tee /tmp/gwa-output.txt
+
+          # Check results
+          if grep -q "Published" /tmp/gwa-output.txt; then
+            PUBLISHED_COUNT=$(grep -oP '\d+(?=/\d+ Published)' /tmp/gwa-output.txt || echo "0")
+            echo "✅ Published $PUBLISHED_COUNT gateway service(s)"
+
+            if [ "$PUBLISHED_COUNT" -gt 0 ]; then
+              echo "✅ PR gateway config published successfully"
+              echo "   Routes available at: https://gw-fe8c5-notify.dev.api.gov.bc.ca/pr-${{ github.event.number }}/"
+              exit 0
+            fi
           fi
 
-          # Check if publish actually succeeded
-          if grep -q "0/[0-9]* Published" /tmp/gwa-output.txt; then
-            echo "❌ Gateway config failed to publish (0 published)"
-            cat /tmp/gwa-output.txt
-            exit 1
-          fi
-
-          echo "✅ Gateway config published successfully"
+          # If we got here, nothing was published
+          echo "❌ Gateway config failed to publish"
+          cat /tmp/gwa-output.txt
+          exit 1
 
   deploys:
     name: Deploys (${{ github.event.number }})

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,22 +64,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch current production configs from main branch
+      - name: Fetch current DEV config from main branch
         run: |
           # Save current PR branch configs
           mkdir -p /tmp/pr-configs
           cp -r api-gateway /tmp/pr-configs/
 
-          # Fetch main branch to get production configs
+          # Fetch main branch to get DEV config
           git fetch origin main
           git checkout origin/main -- api-gateway/
 
-          # Generate production configs (DEV+TEST+PROD) from main branch
-          chmod +x api-gateway/scripts/generate-gateway-for-stage.sh
-          api-gateway/scripts/generate-gateway-for-stage.sh prod
+          # Generate DEV config only from main branch
+          # DEV and PR share the same gateway tag (ns.gw-fe8c5.dev) so they must be published together
+          # TEST and PROD have separate tags and remain unchanged
+          chmod +x api-gateway/scripts/generate-gateway-config.sh
+          api-gateway/scripts/generate-gateway-config.sh dev
 
-          # Save production configs
-          cp api-gateway/generated/gw-active-services.yaml /tmp/prod-configs.yaml
+          # Save DEV config
+          cp api-gateway/generated/gw-routes-dev.yaml /tmp/dev-config.yaml
 
       - name: Generate PR config from PR branch
         run: |
@@ -91,12 +93,13 @@ jobs:
           chmod +x api-gateway/scripts/generate-gateway-config.sh
           api-gateway/scripts/generate-gateway-config.sh pr common-notify-${{ github.event.number }}
 
-          # Combine: Production configs (main) + PR config (PR branch)
-          cp /tmp/prod-configs.yaml api-gateway/generated/gw-combined-pr.yaml
-          echo "---" >> api-gateway/generated/gw-combined-pr.yaml
-          cat api-gateway/generated/gw-routes-pr.yaml >> api-gateway/generated/gw-combined-pr.yaml
+          # Combine: DEV config (main) + PR config (PR branch)
+          # Both share the same gateway tag (ns.gw-fe8c5.dev) for path-based routing
+          cp /tmp/dev-config.yaml api-gateway/generated/gw-combined-dev-pr.yaml
+          echo "---" >> api-gateway/generated/gw-combined-dev-pr.yaml
+          cat api-gateway/generated/gw-routes-pr.yaml >> api-gateway/generated/gw-combined-dev-pr.yaml
 
-      - name: Apply PR config without touching production
+      - name: Apply DEV+PR config (path-based routing)
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
@@ -112,9 +115,11 @@ jobs:
           # Set gateway context
           gwa config set gateway gw-fe8c5
 
-          # Apply: Production configs (from main) + New PR config (from PR branch)
-          echo "✅ Applying PR config with CURRENT production configs (DEV/TEST/PROD unchanged)"
-          gwa apply -i api-gateway/generated/gw-combined-pr.yaml
+          # Apply: DEV config (from main) + PR config (from PR branch)
+          # Both share tag ns.gw-fe8c5.dev for path-based routing
+          # TEST and PROD configs remain unchanged (separate tags, already published)
+          echo "✅ Applying DEV+PR config (path-based routing on shared tag ns.gw-fe8c5.dev)"
+          gwa apply -i api-gateway/generated/gw-combined-dev-pr.yaml
 
   deploys:
     name: Deploys (${{ github.event.number }})

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -115,11 +115,27 @@ jobs:
           # Set gateway context
           gwa config set gateway gw-fe8c5
 
-          # Apply: DEV config (from main) + PR config (from PR branch)
+          # Publish: DEV config (from main) + PR config (from PR branch)
           # Both share tag ns.gw-fe8c5.dev for path-based routing
           # TEST and PROD configs remain unchanged (separate tags, already published)
-          echo "✅ Applying DEV+PR config (path-based routing on shared tag ns.gw-fe8c5.dev)"
-          gwa apply -i api-gateway/generated/gw-combined-dev-pr.yaml
+          echo "✅ Publishing DEV+PR config (path-based routing on shared tag ns.gw-fe8c5.dev)"
+
+          # Use publish-gateway with --qualifier dev (both DEV and PR share this qualifier)
+          # This properly handles updating existing services instead of trying to create them
+          if ! gwa publish-gateway api-gateway/generated/gw-combined-dev-pr.yaml --qualifier dev 2>&1 | tee /tmp/gwa-output.txt; then
+            echo "❌ gwa publish-gateway command failed"
+            cat /tmp/gwa-output.txt
+            exit 1
+          fi
+
+          # Check if publish actually succeeded
+          if grep -q "0/[0-9]* Published" /tmp/gwa-output.txt; then
+            echo "❌ Gateway config failed to publish (0 published)"
+            cat /tmp/gwa-output.txt
+            exit 1
+          fi
+
+          echo "✅ Gateway config published successfully"
 
   deploys:
     name: Deploys (${{ github.event.number }})

--- a/api-gateway/config/dev.env
+++ b/api-gateway/config/dev.env
@@ -12,3 +12,6 @@ KEYCLOAK_ISSUER=https://dev.loginproxy.gov.bc.ca/auth/realms/apigw
 FRONTEND_KEYCLOAK_ISSUER=https://dev.loginproxy.gov.bc.ca/auth/realms/standard
 ALLOWED_AUDIENCE=ap-${GATEWAY_ID}-default-dev-dev
 FRONTEND_ALLOWED_AUDIENCE=notify-6388
+
+# No path prefix for permanent environments
+PATH_PREFIX=

--- a/api-gateway/config/pr.env
+++ b/api-gateway/config/pr.env
@@ -14,7 +14,12 @@ BACKEND_HOST=${RELEASE_NAME}-backend.f6bc3f-dev.svc.cluster.local
 # Route prefix includes PR number to avoid conflicts
 ROUTE_PREFIX=${GATEWAY_ID}-pr-${PR_NUMBER}-
 
-# All PRs share the same DEV gateway hostname
+# PATH PREFIX for isolated PR routing on shared hostname
+# Each PR gets unique path prefix: /pr-109/, /pr-113/, etc.
+# Kong will strip this prefix before forwarding to backend
+PATH_PREFIX=/pr-${PR_NUMBER}
+
+# All PRs share the same DEV gateway hostname (path-based routing)
 GATEWAY_HOSTNAME=${GATEWAY_ID}-notify.dev.api.gov.bc.ca
 
 # DEV Keycloak configuration
@@ -23,4 +28,6 @@ FRONTEND_KEYCLOAK_ISSUER=https://dev.loginproxy.gov.bc.ca/auth/realms/standard
 ALLOWED_AUDIENCE=ap-${GATEWAY_ID}-default-dev-dev
 FRONTEND_ALLOWED_AUDIENCE=notify-6388
 
-# Environment: DEV (PR deployments use DEV namespace and configuration)
+# Environment: PRs use DEV environment qualifier to avoid "too many qualified gateways" error
+# Path prefix provides isolation between PRs, not tag qualifier
+ENVIRONMENT=dev

--- a/api-gateway/config/prod.env
+++ b/api-gateway/config/prod.env
@@ -10,3 +10,6 @@ KEYCLOAK_ISSUER=https://loginproxy.gov.bc.ca/auth/realms/apigw
 FRONTEND_KEYCLOAK_ISSUER=https://loginproxy.gov.bc.ca/auth/realms/standard
 ALLOWED_AUDIENCE=ap-${GATEWAY_ID}-default-prod
 FRONTEND_ALLOWED_AUDIENCE=notify-6388
+
+# No path prefix for permanent environments
+PATH_PREFIX=

--- a/api-gateway/config/test.env
+++ b/api-gateway/config/test.env
@@ -10,3 +10,6 @@ KEYCLOAK_ISSUER=https://test.loginproxy.gov.bc.ca/auth/realms/apigw
 FRONTEND_KEYCLOAK_ISSUER=https://test.loginproxy.gov.bc.ca/auth/realms/standard
 ALLOWED_AUDIENCE=ap-${GATEWAY_ID}-default-test-test
 FRONTEND_ALLOWED_AUDIENCE=notify-6388
+
+# No path prefix for permanent environments
+PATH_PREFIX=

--- a/api-gateway/scripts/generate-gateway-config.sh
+++ b/api-gateway/scripts/generate-gateway-config.sh
@@ -39,10 +39,14 @@ generate_env_config() {
 
   # Load environment variables
   export RELEASE_NAME=$release
-  export ENVIRONMENT=$env
+  # Load env file first (it may define ENVIRONMENT for PR)
   set -a
   source "$ENV_FILE"
   set +a
+  # Only set ENVIRONMENT if not already defined by env file
+  if [ -z "$ENVIRONMENT" ]; then
+    export ENVIRONMENT=$env
+  fi
 
   # Generate config from template
   mkdir -p "${SCRIPT_DIR}/generated"

--- a/api-gateway/templates/routes.yaml
+++ b/api-gateway/templates/routes.yaml
@@ -14,10 +14,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /health
+      - ${PATH_PREFIX}/health
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -27,10 +27,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/health
+      - ${PATH_PREFIX}/api/health
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -45,10 +45,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /ches/api/v1/email
+      - ${PATH_PREFIX}/ches/api/v1/email
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -58,10 +58,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notifysimple
+      - ${PATH_PREFIX}/api/v1/notifysimple
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -71,10 +71,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - ~/api/v1/notifysimple/[^/]+
+      - ~${PATH_PREFIX}/api/v1/notifysimple/[^/]+
     methods:
       - PATCH
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -84,10 +84,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - ~/api/v1/frontend/notifysimple/[^/]+
+      - ~${PATH_PREFIX}/api/v1/frontend/notifysimple/[^/]+
     methods:
       - PATCH
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -97,10 +97,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notifyevent
+      - ${PATH_PREFIX}/api/v1/notifyevent
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -110,10 +110,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notifyevent/preview
+      - ${PATH_PREFIX}/api/v1/notifyevent/preview
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -123,10 +123,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notifyevent/types
+      - ${PATH_PREFIX}/api/v1/notifyevent/types
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -136,11 +136,11 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notify
+      - ${PATH_PREFIX}/api/v1/notify
     methods:
       - GET
       - DELETE
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -150,10 +150,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notify/status
+      - ${PATH_PREFIX}/api/v1/notify/status
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -163,12 +163,12 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notify/registerCallback
+      - ${PATH_PREFIX}/api/v1/notify/registerCallback
     methods:
       - POST
       - PATCH
       - DELETE
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -178,13 +178,13 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/templates
+      - ${PATH_PREFIX}/api/v1/templates
     methods:
       - GET
       - POST
       - PATCH
       - DELETE
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -194,10 +194,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/feature-flags
+      - ${PATH_PREFIX}/api/v1/feature-flags
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -207,10 +207,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/feature-flags
+      - ${PATH_PREFIX}/api/v1/frontend/feature-flags
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -220,10 +220,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/gcnotify/v2/notifications
+      - ${PATH_PREFIX}/api/gcnotify/v2/notifications
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -233,10 +233,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/gcnotify/v2/notifications/email
+      - ${PATH_PREFIX}/api/gcnotify/v2/notifications/email
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -246,10 +246,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/gcnotify/v2/notifications/sms
+      - ${PATH_PREFIX}/api/gcnotify/v2/notifications/sms
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -259,10 +259,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/gcnotify/v2/notifications/bulk
+      - ${PATH_PREFIX}/api/gcnotify/v2/notifications/bulk
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -272,10 +272,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/gcnotify/v2/notifications/*
+      - ${PATH_PREFIX}/api/gcnotify/v2/notifications/*
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -285,10 +285,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/gcnotify/v2/templates
+      - ${PATH_PREFIX}/api/gcnotify/v2/templates
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -298,10 +298,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/gcnotify/v2/template/*
+      - ${PATH_PREFIX}/api/gcnotify/v2/template/*
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -320,10 +320,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/code-tables
+      - ${PATH_PREFIX}/api/v1/code-tables
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -334,10 +334,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/code-tables
+      - ${PATH_PREFIX}/api/v1/frontend/code-tables
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -349,10 +349,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/code-tables/notification-status
+      - ${PATH_PREFIX}/api/v1/code-tables/notification-status
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -363,10 +363,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/code-tables/notification-status
+      - ${PATH_PREFIX}/api/v1/frontend/code-tables/notification-status
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -378,10 +378,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/code-tables/channels
+      - ${PATH_PREFIX}/api/v1/code-tables/channels
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -392,10 +392,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/code-tables/channels
+      - ${PATH_PREFIX}/api/v1/frontend/code-tables/channels
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -407,10 +407,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/code-tables/event-types
+      - ${PATH_PREFIX}/api/v1/code-tables/event-types
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -421,10 +421,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/code-tables/event-types
+      - ${PATH_PREFIX}/api/v1/frontend/code-tables/event-types
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -436,10 +436,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/code-tables/feature-flags
+      - ${PATH_PREFIX}/api/v1/code-tables/feature-flags
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -451,10 +451,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/code-tables/feature-flags
+      - ${PATH_PREFIX}/api/v1/frontend/code-tables/feature-flags
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -466,10 +466,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/notification_request
+      - ${PATH_PREFIX}/api/v1/notification_request
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -480,10 +480,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/notification_request
+      - ${PATH_PREFIX}/api/v1/frontend/notification_request
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -494,10 +494,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/notification_request/events
+      - ${PATH_PREFIX}/api/v1/frontend/notification_request/events
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: false
@@ -509,10 +509,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/admin/tenants
+      - ${PATH_PREFIX}/api/v1/admin/tenants
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -524,10 +524,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/users/me
+      - ${PATH_PREFIX}/api/v1/frontend/users/me
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -539,10 +539,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/users
+      - ${PATH_PREFIX}/api/v1/frontend/users
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -557,10 +557,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/auth/tenants
+      - ${PATH_PREFIX}/api/v1/frontend/auth/tenants
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -572,10 +572,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - ~/api/v1/frontend/auth/tenants/[^/]+/roles
+      - ~${PATH_PREFIX}/api/v1/frontend/auth/tenants/[^/]+/roles
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -590,10 +590,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/admin/feature-flags
+      - ${PATH_PREFIX}/api/v1/frontend/admin/feature-flags
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -605,10 +605,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/admin/feature-flags
+      - ${PATH_PREFIX}/api/v1/frontend/admin/feature-flags
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -620,10 +620,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/admin/feature-flags/
+      - ${PATH_PREFIX}/api/v1/frontend/admin/feature-flags/
     methods:
       - PATCH
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -635,10 +635,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/admin/feature-flags/
+      - ${PATH_PREFIX}/api/v1/frontend/admin/feature-flags/
     methods:
       - DELETE
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -650,10 +650,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/templates
+      - ${PATH_PREFIX}/api/v1/frontend/templates
     methods:
       - GET
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -665,10 +665,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/templates
+      - ${PATH_PREFIX}/api/v1/frontend/templates
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true
@@ -680,12 +680,12 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/templates/*
+      - ${PATH_PREFIX}/api/v1/frontend/templates/*
     methods:
       - GET
       - POST
       - DELETE
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v1
     request_buffering: true
@@ -697,10 +697,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/frontend/templates/*/preview
+      - ${PATH_PREFIX}/api/v1/frontend/templates/*/preview
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v1
     request_buffering: true
@@ -719,10 +719,10 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - /api/v1/service/api-key/bind
+      - ${PATH_PREFIX}/api/v1/service/api-key/bind
     methods:
       - POST
-    strip_path: false
+    strip_path: true
     https_redirect_status_code: 426
     path_handling: v0
     request_buffering: true

--- a/api-gateway/templates/routes.yaml
+++ b/api-gateway/templates/routes.yaml
@@ -272,7 +272,7 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - ${PATH_PREFIX}/api/gcnotify/v2/notifications/*
+      - ~${PATH_PREFIX}/api/gcnotify/v2/notifications/*
     methods:
       - GET
     strip_path: true
@@ -298,7 +298,7 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - ${PATH_PREFIX}/api/gcnotify/v2/template/*
+      - ~${PATH_PREFIX}/api/gcnotify/v2/template/*
     methods:
       - GET
     strip_path: true
@@ -680,7 +680,7 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - ${PATH_PREFIX}/api/v1/frontend/templates/*
+      - ~${PATH_PREFIX}/api/v1/frontend/templates/*
     methods:
       - GET
       - POST
@@ -697,7 +697,7 @@ routes:
     hosts:
       - ${GATEWAY_HOSTNAME}
     paths:
-      - ${PATH_PREFIX}/api/v1/frontend/templates/*/preview
+      - ~${PATH_PREFIX}/api/v1/frontend/templates/*/preview
     methods:
       - POST
     strip_path: true


### PR DESCRIPTION
Implements path-based routing to enable unlimited PR environments while staying within BC Gov API Gateway's 3 qualified gateway limit (dev, test, prod).

Key Changes:
- PRs now use ENVIRONMENT=dev tag instead of pr tag
- Each PR gets unique path prefix: /pr-{PR_NUMBER}/
- Kong strips prefix before forwarding to PR backend
- All 49 routes updated to include ${PATH_PREFIX} variable
- strip_path set to true on all routes
- PR workflow updated to apply DEV+PR configs together

Architecture:
- DEV: tag ns.gw-fe8c5.dev, path /health
- PR-113: tag ns.gw-fe8c5.dev, path /pr-113/health
- Both routes coexist via path-based routing
- TEST and PROD remain unchanged (separate tags)

This allows unlimited PRs while using only 3 gateway qualifiers.

Validated by Barrett (API Gateway expert) and manual testing.

<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [x] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-118.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-118.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)