### PR TITLE
feat: ccp-4866-hide-body-type-for-MJML-templates

### DIFF
--- a/backend/src/api/templates/entities/template-version.entity.ts
+++ b/backend/src/api/templates/entities/template-version.entity.ts
@@ -105,8 +105,8 @@ export class TemplateVersion {
   /**
    * Body content type for this version: 'text' (plain), 'markdown' (markdown→HTML), 'html' (raw HTML)
    */
-  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'html' })
-  bodyType: 'text' | 'markdown' | 'html'
+  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'html', nullable: true })
+  bodyType?: 'text' | 'markdown' | 'html' | null
 
   /**
    * User or process that created this version

--- a/backend/src/api/templates/entities/template.entity.ts
+++ b/backend/src/api/templates/entities/template.entity.ts
@@ -103,8 +103,8 @@ export class Template {
    * Body content type: 'text' (plain), 'markdown' (markdown→HTML), 'html' (raw HTML)
    * Determines rendering behavior during template rendering
    */
-  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'html' })
-  bodyType: 'text' | 'markdown' | 'html'
+  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'html', nullable: true })
+  bodyType?: 'text' | 'markdown' | 'html' | null
 
   /**
    * Current version number

--- a/backend/src/api/templates/schemas/create-template.dto.ts
+++ b/backend/src/api/templates/schemas/create-template.dto.ts
@@ -62,7 +62,7 @@ export class CreateTemplateDto {
 
   /**
    * Body content type for rendering: text (plain), markdown (markdown→HTML), html (raw HTML)
-   * Defaults to 'html'
+   * Optional for MJML templates
    * @example "markdown"
    */
   @IsOptional()

--- a/backend/src/api/templates/schemas/update-template.dto.ts
+++ b/backend/src/api/templates/schemas/update-template.dto.ts
@@ -55,4 +55,13 @@ export class UpdateTemplateDto extends PartialType(CreateTemplateDto) {
   @IsOptional()
   @IsEnum(TemplateEngine)
   engineCode?: TemplateEngine
+
+  /**
+   * Body content type for rendering
+   * Optional for MJML templates
+   * @example "html"
+   */
+  @IsOptional()
+  @IsEnum(['text', 'markdown', 'html'])
+  bodyType?: 'text' | 'markdown' | 'html'
 }

--- a/backend/src/api/templates/templates.service.spec.ts
+++ b/backend/src/api/templates/templates.service.spec.ts
@@ -50,6 +50,7 @@ describe('TemplatesService', () => {
       </mjml>
     `,
     engineCode: TemplateEngine.MJML,
+    bodyType: null,
   }
 
   const mockMjmlSmsTemplate: Template = {
@@ -106,6 +107,16 @@ describe('TemplatesService', () => {
 
       expect(result.subject).toBe('Welcome to MyApp!')
       expect(result.body).toBe('Hello John, welcome!')
+      expect(result.bodyType).toBe('html')
+    })
+
+    it('should fall back to html when stored MJML bodyType is null', async () => {
+      const result = await service.renderTemplateContent(mockMjmlTemplate, {
+        userName: 'John',
+      })
+
+      expect(result.subject).toBe('Welcome John')
+      expect(result.body).toContain('<!doctype html>')
       expect(result.bodyType).toBe('html')
     })
 
@@ -287,6 +298,39 @@ describe('TemplatesService', () => {
         }),
       )
     })
+
+    it('should store null bodyType for MJML when not provided', async () => {
+      const createDto = {
+        name: 'MJML Template',
+        description: 'Test',
+        channelCode: NotificationChannel.EMAIL,
+        subject: 'Subject',
+        body: '<mjml><mj-body><mj-section><mj-column><mj-text>Hello</mj-text></mj-column></mj-section></mj-body></mjml>',
+        engineCode: TemplateEngine.MJML,
+      }
+
+      mockRepository.create.mockResolvedValue({
+        ...mockTemplate,
+        ...createDto,
+        bodyType: null,
+      })
+      mockRepository.createVersion.mockResolvedValue({})
+
+      await service.createTemplate('tenant-123', createDto, 'user-123')
+
+      expect(mockRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          engineCode: TemplateEngine.MJML,
+          bodyType: null,
+        }),
+      )
+
+      expect(mockRepository.createVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bodyType: null,
+        }),
+      )
+    })
   })
 
   describe('updateTemplate', () => {
@@ -326,6 +370,28 @@ describe('TemplatesService', () => {
       expect(mockRepository.update).toHaveBeenCalledWith(
         expect.objectContaining({
           bodyType: 'markdown',
+        }),
+      )
+    })
+
+    it('should clear bodyType when template engine changes to MJML', async () => {
+      const updateDto = {
+        engineCode: TemplateEngine.MJML,
+      }
+
+      mockRepository.findById.mockResolvedValue(mockTemplate)
+      mockRepository.update.mockResolvedValue({
+        ...mockTemplate,
+        ...updateDto,
+        bodyType: null,
+      })
+
+      await service.updateTemplate('tenant-123', 'template-123', updateDto, 'user-123')
+
+      expect(mockRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          engineCode: TemplateEngine.MJML,
+          bodyType: null,
         }),
       )
     })

--- a/backend/src/api/templates/templates.service.ts
+++ b/backend/src/api/templates/templates.service.ts
@@ -137,6 +137,9 @@ export class TemplatesService {
       throw new ConflictException(`Template name "${createDto.name}" already exists`)
     }
 
+    const engineCode = createDto.engineCode || TemplateEngine.HANDLEBARS
+    const bodyType = engineCode === TemplateEngine.MJML ? null : (createDto.bodyType ?? 'html')
+
     const template = await this.templatesRepository.create({
       tenantId,
       name: createDto.name,
@@ -144,8 +147,8 @@ export class TemplatesService {
       channelCode: createDto.channelCode,
       subject: createDto.subject,
       body: createDto.body,
-      engineCode: createDto.engineCode || TemplateEngine.HANDLEBARS,
-      bodyType: createDto.bodyType || 'html',
+      engineCode,
+      bodyType,
       version: 1,
       active: true,
       createdBy: userId,
@@ -205,13 +208,18 @@ export class TemplatesService {
     }
 
     // Update the template
+    const nextEngineCode = updateDto.engineCode || template.engineCode
     template.name = updateDto.name || template.name
     template.description = updateDto.description ?? template.description
     template.channelCode = updateDto.channelCode || template.channelCode
     template.subject = updateDto.subject ?? template.subject
     template.body = updateDto.body || template.body
-    template.engineCode = updateDto.engineCode || template.engineCode
-    template.bodyType = updateDto.bodyType ?? template.bodyType
+    template.engineCode = nextEngineCode
+    if (nextEngineCode === TemplateEngine.MJML) {
+      template.bodyType = null
+    } else {
+      template.bodyType = updateDto.bodyType ?? template.bodyType ?? 'html'
+    }
     template.updatedBy = userId
 
     const updated = await this.templatesRepository.update(template)

--- a/frontend/src/api/templates.api.ts
+++ b/frontend/src/api/templates.api.ts
@@ -26,7 +26,7 @@ export interface TemplateResponse {
   channelCode: NotificationChannel
   subject?: string
   body: string
-  bodyType: TemplateBodyType
+  bodyType?: TemplateBodyType
   engineCode: TemplateEngine
   version: number
   active: boolean

--- a/frontend/src/pages/templates/TemplateCreate.spec.tsx
+++ b/frontend/src/pages/templates/TemplateCreate.spec.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type * as TemplatesApi from '@/api/templates.api'
+import TemplateCreate from './TemplateCreate'
+
+const navigateMock = vi.fn()
+const createTemplateMock = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock('@/api/templates.api', async () => {
+  const actual = await vi.importActual<typeof TemplatesApi>('@/api/templates.api')
+  return {
+    ...actual,
+    createTemplate: (...args: unknown[]) => createTemplateMock(...args),
+  }
+})
+
+vi.mock('@/redux/utils/toastUtils', () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}))
+
+vi.mock('@/components/PageHeading', () => ({
+  default: ({ title }: { title: string }) => <h1>{title}</h1>,
+}))
+
+vi.mock('@bcgov/design-system-react-components', async () => {
+  const React = await import('react')
+
+  const Button = ({
+    children,
+    onClick,
+    onPress,
+    type,
+    isDisabled,
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    onPress?: () => void
+    type?: 'button' | 'submit'
+    isDisabled?: boolean
+  }) => (
+    <button disabled={isDisabled} onClick={onClick ?? onPress} type={type ?? 'button'}>
+      {children}
+    </button>
+  )
+
+  const TextField = ({
+    label,
+    value,
+    onChange,
+    description,
+    errorMessage,
+  }: {
+    label: ReactNode
+    value: string
+    onChange: (value: string) => void
+    description?: string
+    errorMessage?: string
+  }) => (
+    <label>
+      {label}
+      <input value={value} onChange={(event) => onChange(event.target.value)} />
+      {description ? <span>{description}</span> : null}
+      {errorMessage ? <span>{errorMessage}</span> : null}
+    </label>
+  )
+
+  const Radio = ({
+    value,
+    children,
+    checked,
+    onSelect,
+    disabled,
+  }: {
+    value: string
+    children: ReactNode
+    checked?: boolean
+    onSelect?: (value: string) => void
+    disabled?: boolean
+  }) => (
+    <label>
+      <input
+        checked={checked}
+        disabled={disabled}
+        name="radio-group"
+        onChange={() => onSelect?.(value)}
+        type="radio"
+      />
+      {children}
+    </label>
+  )
+
+  const RadioGroup = ({
+    label,
+    value,
+    onChange,
+    children,
+    errorMessage,
+    isDisabled,
+  }: {
+    label: ReactNode
+    value: string
+    onChange: (value: string) => void
+    children: ReactNode
+    errorMessage?: string
+    isDisabled?: boolean
+  }) => (
+    <fieldset disabled={isDisabled}>
+      <legend>{label}</legend>
+      {React.Children.map(children, (child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, {
+              checked: child.props.value === value,
+              onSelect: onChange,
+              disabled: isDisabled,
+            })
+          : child,
+      )}
+      {errorMessage ? <span>{errorMessage}</span> : null}
+    </fieldset>
+  )
+
+  return { Button, Radio, RadioGroup, TextField }
+})
+
+describe('TemplateCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createTemplateMock.mockResolvedValue({})
+  })
+
+  it('hides body type when MJML is selected', () => {
+    render(<TemplateCreate />)
+
+    expect(screen.getByText('Body type')).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('MJML'))
+
+    expect(screen.queryByText('Body type')).toBeNull()
+  })
+
+  it('does not require or send bodyType when saving an MJML template', async () => {
+    render(<TemplateCreate />)
+
+    fireEvent.click(screen.getByLabelText('Email'))
+    fireEvent.click(screen.getByLabelText('MJML'))
+
+    const [titleInput, subjectInput, bodyTextarea] = screen.getAllByRole('textbox')
+
+    fireEvent.change(titleInput, {
+      target: { value: 'local mjml final test' },
+    })
+    fireEvent.change(subjectInput, {
+      target: { value: 'Hello {{name}}' },
+    })
+    fireEvent.change(bodyTextarea, {
+      target: {
+        value:
+          '<mjml><mj-body><mj-section><mj-column><mj-text>Hello {{name}}</mj-text></mj-column></mj-section></mj-body></mjml>',
+      },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(createTemplateMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(createTemplateMock).toHaveBeenCalledWith({
+      name: 'local mjml final test',
+      channelCode: 'EMAIL',
+      engineCode: 'mjml',
+      subject: 'Hello {{name}}',
+      body: '<mjml><mj-body><mj-section><mj-column><mj-text>Hello {{name}}</mj-text></mj-column></mj-section></mj-body></mjml>',
+    })
+  })
+})

--- a/frontend/src/pages/templates/TemplateCreate.tsx
+++ b/frontend/src/pages/templates/TemplateCreate.tsx
@@ -33,6 +33,7 @@ const TemplateCreate: FC = () => {
   })
 
   const isSaveDisabled = saving || !formData.name.trim()
+  const isMjml = formData.engineCode === TemplateEngine.MJML
 
   const handleFieldChange = (field: string) => (value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
@@ -57,7 +58,7 @@ const TemplateCreate: FC = () => {
     if (!formData.engineCode) {
       errors.engineCode = 'Please select an option to continue.'
     }
-    if (!formData.bodyType) {
+    if (!isMjml && !formData.bodyType) {
       errors.bodyType = 'Please select an option to continue.'
     }
     if (formData.channelCode === NotificationChannel.EMAIL && !formData.subject.trim()) {
@@ -79,9 +80,11 @@ const TemplateCreate: FC = () => {
         name: formData.name,
         channelCode: formData.channelCode as NotificationChannel,
         engineCode: formData.engineCode as TemplateEngine,
-        bodyType: formData.bodyType as TemplateBodyType,
         subject: formData.channelCode === NotificationChannel.EMAIL ? formData.subject : undefined,
         body: formData.body,
+        ...(!isMjml && formData.bodyType
+          ? { bodyType: formData.bodyType as TemplateBodyType }
+          : {}),
       })
       showSuccessToast('Template created successfully')
       navigate({ to: '/templates' })
@@ -160,8 +163,16 @@ const TemplateCreate: FC = () => {
               }
               value={formData.engineCode}
               onChange={(value) => {
-                setFormData((prev) => ({ ...prev, engineCode: value }))
-                setFormErrors((prev) => ({ ...prev, engineCode: '' }))
+                setFormData((prev) => ({
+                  ...prev,
+                  engineCode: value,
+                  bodyType: value === TemplateEngine.MJML ? '' : prev.bodyType,
+                }))
+                setFormErrors((prev) => ({
+                  ...prev,
+                  engineCode: '',
+                  bodyType: '',
+                }))
               }}
               isInvalid={!!formErrors.engineCode}
               errorMessage={formErrors.engineCode}
@@ -181,31 +192,33 @@ const TemplateCreate: FC = () => {
             </RadioGroup>
           </div>
 
-          <div className="mb-4 error-after-label">
-            <RadioGroup
-              label={
-                (
-                  <>
-                    <strong>Body type</strong> (required)
-                  </>
-                ) as any
-              }
-              value={formData.bodyType}
-              onChange={(value) => {
-                setFormData((prev) => ({ ...prev, bodyType: value }))
-                setFormErrors((prev) => ({ ...prev, bodyType: '' }))
-              }}
-              isInvalid={!!formErrors.bodyType}
-              errorMessage={formErrors.bodyType}
-            >
-              <Radio key="html" value={TemplateBodyType.HTML}>
-                HTML
-              </Radio>
-              <Radio key="markdown" value={TemplateBodyType.MARKDOWN}>
-                Markdown
-              </Radio>
-            </RadioGroup>
-          </div>
+          {!isMjml && (
+            <div className="mb-4 error-after-label">
+              <RadioGroup
+                label={
+                  (
+                    <>
+                      <strong>Body type</strong> (required)
+                    </>
+                  ) as any
+                }
+                value={formData.bodyType}
+                onChange={(value) => {
+                  setFormData((prev) => ({ ...prev, bodyType: value }))
+                  setFormErrors((prev) => ({ ...prev, bodyType: '' }))
+                }}
+                isInvalid={!!formErrors.bodyType}
+                errorMessage={formErrors.bodyType}
+              >
+                <Radio key="html" value={TemplateBodyType.HTML}>
+                  HTML
+                </Radio>
+                <Radio key="markdown" value={TemplateBodyType.MARKDOWN}>
+                  Markdown
+                </Radio>
+              </RadioGroup>
+            </div>
+          )}
 
           {formData.channelCode === NotificationChannel.EMAIL && (
             <div className="mb-4 desc-above">

--- a/frontend/src/pages/templates/TemplateEdit.spec.tsx
+++ b/frontend/src/pages/templates/TemplateEdit.spec.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type * as TemplatesApi from '@/api/templates.api'
+import TemplateEdit from './TemplateEdit'
+
+const navigateMock = vi.fn()
+const getTemplateByIdMock = vi.fn()
+const updateTemplateMock = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock('@/api/templates.api', async () => {
+  const actual = await vi.importActual<typeof TemplatesApi>('@/api/templates.api')
+  return {
+    ...actual,
+    getTemplateById: (...args: unknown[]) => getTemplateByIdMock(...args),
+    updateTemplate: (...args: unknown[]) => updateTemplateMock(...args),
+  }
+})
+
+vi.mock('@/redux/utils/toastUtils', () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}))
+
+vi.mock('@/components/PageHeading', () => ({
+  default: ({ title }: { title: string }) => <h1>{title}</h1>,
+}))
+
+vi.mock('@bcgov/design-system-react-components', async () => {
+  const React = await import('react')
+
+  const Button = ({
+    children,
+    onClick,
+    onPress,
+    type,
+    isDisabled,
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    onPress?: () => void
+    type?: 'button' | 'submit'
+    isDisabled?: boolean
+  }) => (
+    <button disabled={isDisabled} onClick={onClick ?? onPress} type={type ?? 'button'}>
+      {children}
+    </button>
+  )
+
+  const TextField = ({
+    label,
+    value,
+    onChange,
+    description,
+    errorMessage,
+  }: {
+    label: ReactNode
+    value: string
+    onChange: (value: string) => void
+    description?: string
+    errorMessage?: string
+  }) => (
+    <label>
+      {label}
+      <input value={value} onChange={(event) => onChange(event.target.value)} />
+      {description ? <span>{description}</span> : null}
+      {errorMessage ? <span>{errorMessage}</span> : null}
+    </label>
+  )
+
+  const Radio = ({
+    value,
+    children,
+    checked,
+    onSelect,
+    disabled,
+  }: {
+    value: string
+    children: ReactNode
+    checked?: boolean
+    onSelect?: (value: string) => void
+    disabled?: boolean
+  }) => (
+    <label>
+      <input
+        checked={checked}
+        disabled={disabled}
+        name="radio-group"
+        onChange={() => onSelect?.(value)}
+        type="radio"
+      />
+      {children}
+    </label>
+  )
+
+  const RadioGroup = ({
+    label,
+    value,
+    onChange,
+    children,
+    errorMessage,
+    isDisabled,
+  }: {
+    label: ReactNode
+    value: string
+    onChange: (value: string) => void
+    children: ReactNode
+    errorMessage?: string
+    isDisabled?: boolean
+  }) => (
+    <fieldset disabled={isDisabled}>
+      <legend>{label}</legend>
+      {React.Children.map(children, (child) =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, {
+              checked: child.props.value === value,
+              onSelect: onChange,
+              disabled: isDisabled,
+            })
+          : child,
+      )}
+      {errorMessage ? <span>{errorMessage}</span> : null}
+    </fieldset>
+  )
+
+  return { Button, Radio, RadioGroup, TextField }
+})
+
+const template = {
+  id: 'template-123',
+  name: 'Welcome Template',
+  channelCode: 'EMAIL',
+  engineCode: 'handlebars',
+  bodyType: 'html',
+  subject: 'Hello {{name}}',
+  body: 'Hello {{name}}',
+  version: 1,
+  active: true,
+  createdBy: 'user',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedBy: 'user',
+  updatedAt: '2026-01-01T00:00:00Z',
+}
+
+describe('TemplateEdit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getTemplateByIdMock.mockResolvedValue(template)
+    updateTemplateMock.mockResolvedValue({})
+  })
+
+  it('hides body type when the loaded template engine is MJML', async () => {
+    getTemplateByIdMock.mockResolvedValue({
+      ...template,
+      engineCode: 'mjml',
+      bodyType: undefined,
+    })
+
+    render(<TemplateEdit templateId="template-123" />)
+
+    await waitFor(() => {
+      expect(getTemplateByIdMock).toHaveBeenCalledWith('template-123')
+    })
+
+    expect(screen.queryByText('Body type')).toBeNull()
+  })
+
+  it('does not require or send bodyType when saving an MJML template', async () => {
+    render(<TemplateEdit templateId="template-123" />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Welcome Template')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByLabelText('MJML'))
+    fireEvent.change(screen.getByLabelText('Template body (required)'), {
+      target: {
+        value:
+          '<mjml><mj-body><mj-section><mj-column><mj-text>Hello {{name}}</mj-text></mj-column></mj-section></mj-body></mjml>',
+      },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(updateTemplateMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(updateTemplateMock).toHaveBeenCalledWith('template-123', {
+      name: 'Welcome Template',
+      engineCode: 'mjml',
+      subject: 'Hello {{name}}',
+      body: '<mjml><mj-body><mj-section><mj-column><mj-text>Hello {{name}}</mj-text></mj-column></mj-section></mj-body></mjml>',
+    })
+  })
+})

--- a/frontend/src/pages/templates/TemplateEdit.tsx
+++ b/frontend/src/pages/templates/TemplateEdit.tsx
@@ -38,6 +38,7 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
     subject: '',
     body: '',
   })
+  const isMjml = formData.engineCode === TemplateEngine.MJML
 
   useEffect(() => {
     const fetchTemplate = async () => {
@@ -76,7 +77,7 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
     if (!formData.engineCode) {
       errors.engineCode = 'Please select an option to continue.'
     }
-    if (!formData.bodyType) {
+    if (!isMjml && !formData.bodyType) {
       errors.bodyType = 'Please select an option to continue.'
     }
     if (formData.channelCode === NotificationChannel.EMAIL && !formData.subject.trim()) {
@@ -97,9 +98,11 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
       await updateTemplate(templateId, {
         name: formData.name,
         engineCode: formData.engineCode as TemplateEngine,
-        bodyType: formData.bodyType as TemplateBodyType,
         subject: formData.channelCode === NotificationChannel.EMAIL ? formData.subject : undefined,
         body: formData.body,
+        ...(!isMjml && formData.bodyType
+          ? { bodyType: formData.bodyType as TemplateBodyType }
+          : {}),
       })
       showSuccessToast('Template saved successfully')
       navigate({ to: '/templates' })
@@ -187,16 +190,16 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
               }
               value={formData.engineCode}
               onChange={(value) => {
-                setFormData((prev) => ({ ...prev, engineCode: value }))
-                setFormErrors((prev) => ({ ...prev, engineCode: '' }))
+                setFormData((prev) => ({
+                  ...prev,
+                  engineCode: value,
+                  bodyType: value === TemplateEngine.MJML ? '' : prev.bodyType,
+                }))
+                setFormErrors((prev) => ({ ...prev, engineCode: '', bodyType: '' }))
               }}
               isInvalid={!!formErrors.engineCode}
               errorMessage={formErrors.engineCode}
             >
-              <Radio value={TemplateEngine.HANDLEBARS}>Handlebars</Radio>
-              <Radio value={TemplateEngine.MUSTACHE}>Mustache</Radio>
-              <Radio value={TemplateEngine.LEGACY_GC_NOTIFY}>Legacy GC Notify</Radio>
-              <Radio value={TemplateEngine.MJML}>MJML</Radio>
               <Radio key="handlebars" value={TemplateEngine.HANDLEBARS}>
                 Handlebars
               </Radio>
@@ -206,34 +209,39 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
               <Radio key="legacy" value={TemplateEngine.LEGACY_GC_NOTIFY}>
                 Legacy GC Notify
               </Radio>
+              <Radio key="mjml" value={TemplateEngine.MJML}>
+                MJML
+              </Radio>
             </RadioGroup>
           </div>
 
-          <div className="mb-4 error-after-label">
-            <RadioGroup
-              label={
-                (
-                  <>
-                    <strong>Body type</strong> (required)
-                  </>
-                ) as any
-              }
-              value={formData.bodyType}
-              onChange={(value) => {
-                setFormData((prev) => ({ ...prev, bodyType: value }))
-                setFormErrors((prev) => ({ ...prev, bodyType: '' }))
-              }}
-              isInvalid={!!formErrors.bodyType}
-              errorMessage={formErrors.bodyType}
-            >
-              <Radio key="html" value={TemplateBodyType.HTML}>
-                HTML
-              </Radio>
-              <Radio key="markdown" value={TemplateBodyType.MARKDOWN}>
-                Markdown
-              </Radio>
-            </RadioGroup>
-          </div>
+          {!isMjml && (
+            <div className="mb-4 error-after-label">
+              <RadioGroup
+                label={
+                  (
+                    <>
+                      <strong>Body type</strong> (required)
+                    </>
+                  ) as any
+                }
+                value={formData.bodyType}
+                onChange={(value) => {
+                  setFormData((prev) => ({ ...prev, bodyType: value }))
+                  setFormErrors((prev) => ({ ...prev, bodyType: '' }))
+                }}
+                isInvalid={!!formErrors.bodyType}
+                errorMessage={formErrors.bodyType}
+              >
+                <Radio key="html" value={TemplateBodyType.HTML}>
+                  HTML
+                </Radio>
+                <Radio key="markdown" value={TemplateBodyType.MARKDOWN}>
+                  Markdown
+                </Radio>
+              </RadioGroup>
+            </div>
+          )}
 
           {formData.channelCode === NotificationChannel.EMAIL && (
             <div className="mb-4 desc-above">

--- a/migrations/sql/V35__make_template_body_type_nullable_for_mjml.sql
+++ b/migrations/sql/V35__make_template_body_type_nullable_for_mjml.sql
@@ -1,0 +1,5 @@
+ALTER TABLE notify.template
+ALTER COLUMN body_type DROP NOT NULL;
+
+ALTER TABLE notify.template_version
+ALTER COLUMN body_type DROP NOT NULL;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Hide the Body type section on the template create and edit screens when the selected template engine is MJML.
This change also makes bodyType optional end-to-end for MJML templates so they can be created and updated with 
body_type = NULL, while preserving existing behavior for non-MJML engines.

**Frontend changes**
Hide the Body type radio group on:frontend/src/pages/templates/TemplateCreate.tsx
frontend/src/pages/templates/TemplateEdit.tsx

Require bodyType only when the selected engine is not MJML.
Clear bodyType when the user switches the selected engine to MJML.
Omit bodyType from create/update requests when the selected engine is MJML.
Make bodyType optional in frontend/src/api/templates.api.ts.


**Backend changes**
Allow bodyType to be nullable in the template entities:backend/src/api/templates/entities/template.entity.ts
backend/src/api/templates/entities/template-version.entity.ts

Update template create/update handling in backend/src/api/templates/templates.service.ts so that:MJML templates store bodyType as null
non-MJML templates continue to default or preserve bodyType as before

Update DTO/schema documentation and optional handling in:backend/src/api/templates/schemas/create-template.dto.ts
backend/src/api/templates/schemas/update-template.dto.ts


Added Flyway migration:migrations/sql/V35__make_template_body_type_nullable_for_mjml.sql

Migration changes:notify.template.body_type to nullable
notify.template_version.body_type to nullable

Fixes # 4866
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->


- [x] Manual tests (description below)
Verified locally:
Created an MJML email template named hello
Confirmed in notify.template:engine_code = mjml
body_type = NULL

Confirmed in notify.template_version:engine_code = mjml
body_type = NULL

Created a Handlebars email template named handlebars
Confirmed in notify.template:engine_code = handlebars
body_type = html

Confirmed Flyway applied successfully and the notify schema version is v35
- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-122.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-122.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)