### PR TITLE
fix: improve CSTAR access guidance on 403 page

### DIFF
--- a/frontend/src/components/NotAuthorized.tsx
+++ b/frontend/src/components/NotAuthorized.tsx
@@ -31,7 +31,6 @@ const NotAuthorized: FC<NotAuthorizedProps> = ({ cstarUrl }) => {
       <p>Please contact your administrator or appropriate access authority to request access.</p>
       {cstarUrl && (
         <>
-          <p className="mt-3">You can manage your service access in CSTAR.</p>
           <Button id="cstarBtn" onClick={handleCstarClick}>
             Open CSTAR
           </Button>

--- a/frontend/src/components/NotAuthorized.tsx
+++ b/frontend/src/components/NotAuthorized.tsx
@@ -6,6 +6,8 @@ interface NotAuthorizedProps {
 }
 
 const NotAuthorized: FC<NotAuthorizedProps> = ({ cstarUrl }) => {
+  const notifyRoles = ['NOTIFY_VIEWER', 'NOTIFY_TEMPLATE_EDITOR', 'NOTIFY_OPERATIONS_ADMIN']
+
   const handleCstarClick = () => {
     if (cstarUrl) {
       window.location.href = cstarUrl
@@ -15,12 +17,21 @@ const NotAuthorized: FC<NotAuthorizedProps> = ({ cstarUrl }) => {
   return (
     <div className="d-flex flex-column justify-content-center align-items-center min-vh-100">
       <h1>403</h1>
-      <h2>Not Authorized</h2>
-      <p>You don&apos;t have the required permissions to access BC Notify.</p>
-      <p>Please contact your administrator to request access.</p>
+      <h2>Access to Tenant Not Available</h2>
+      <p>You don&apos;t currently have access to Notify for this tenant.</p>
+      <p>
+        Access to Notify is managed through CSTAR. To proceed, you must be assigned to
+        the selected tenant with one of the following roles:
+      </p>
+      <ul>
+        {notifyRoles.map((role) => (
+          <li key={role}>{role}</li>
+        ))}
+      </ul>
+      <p>Please contact your administrator or appropriate access authority to request access.</p>
       {cstarUrl && (
         <>
-          <p className="mt-3">You can manage your service access in CSTAR</p>
+          <p className="mt-3">You can manage your service access in CSTAR.</p>
           <Button id="cstarBtn" onClick={handleCstarClick}>
             Open CSTAR
           </Button>

--- a/frontend/src/components/NotAuthorized.tsx
+++ b/frontend/src/components/NotAuthorized.tsx
@@ -20,8 +20,8 @@ const NotAuthorized: FC<NotAuthorizedProps> = ({ cstarUrl }) => {
       <h2>Access to Tenant Not Available</h2>
       <p>You don&apos;t currently have access to Notify for this tenant.</p>
       <p>
-        Access to Notify is managed through CSTAR. To proceed, you must be assigned to
-        the selected tenant with one of the following roles:
+        Access to Notify is managed through CSTAR. To proceed, you must be assigned to the selected
+        tenant with one of the following roles:
       </p>
       <ul>
         {notifyRoles.map((role) => (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Update the not-authorized screen to use tenant-specific CSTAR access guidance. The page now explains that Notify access for the selected tenant must be granted in CSTAR, lists the required roles (NOTIFY_VIEWER, NOTIFY_TEMPLATE_EDITOR, NOTIFY_OPERATIONS_ADMIN), and keeps the existing Open CSTAR action. No routing or backend behavior changed.

Fixes # CCP-4865

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] No new tests are required



## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-140.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-140.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)