### PR TITLE
fix: ccp-4982-remove HTML template body support in templates

### DIFF
--- a/backend/src/adapters/implementations/delivery/email/ches/ches-email.adapter.spec.ts
+++ b/backend/src/adapters/implementations/delivery/email/ches/ches-email.adapter.spec.ts
@@ -376,6 +376,42 @@ describe('ChesEmailTransport', () => {
       expect(String(emailBody.body)).toContain('<h1>')
     })
 
+    it('does not pass raw HTML through markdown rendering', async () => {
+      mockConfig()
+
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              access_token: 'token-123',
+              expires_in: 300,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              messages: [{ msgId: 'msg-md', to: ['user@example.com'] }],
+              txId: 'tx-md',
+            }),
+        })
+
+      await transport.send({
+        to: 'user@example.com',
+        subject: 'Markdown Email',
+        body: 'Hello <script>alert(1)</script>\n\n<div>safe?</div>',
+        bodyType: 'markdown',
+      })
+
+      const [, init] = (fetchMock.mock.calls[1] ?? []) as [string, RequestInit]
+      const bodyStr = typeof init?.body === 'string' ? init.body : ''
+      const emailBody = JSON.parse(bodyStr) as Record<string, unknown>
+      expect(String(emailBody.body)).not.toContain('<script>')
+      expect(String(emailBody.body)).not.toContain('<div>safe?</div>')
+      expect(String(emailBody.body)).toContain('&lt;script&gt;')
+    })
+
     it('uses custom from address when provided', async () => {
       mockConfig()
 

--- a/backend/src/adapters/implementations/delivery/email/ches/ches-email.adapter.ts
+++ b/backend/src/adapters/implementations/delivery/email/ches/ches-email.adapter.ts
@@ -52,9 +52,9 @@ export class ChesEmailTransport implements IEmailTransport {
   private readonly markdown: MarkdownIt
 
   constructor(private readonly configService: ConfigService) {
-    // Initialize markdown-it with safe defaults
+    // Initialize markdown-it with HTML disabled so raw tags are not rendered.
     this.markdown = new MarkdownIt({
-      html: true,
+      html: false,
       linkify: true, // converst urls and links to clickable links
       typographer: true, // enables smart quotes and other typographic replacements
     })

--- a/backend/src/api/templates/entities/template-version.entity.ts
+++ b/backend/src/api/templates/entities/template-version.entity.ts
@@ -103,10 +103,10 @@ export class TemplateVersion {
   engine: TemplateEngineCode
 
   /**
-   * Body content type for this version: 'text' (plain), 'markdown' (markdown→HTML), 'html' (raw HTML)
+   * Body content type for this version: 'markdown' (markdown→HTML)
    */
-  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'html', nullable: true })
-  bodyType?: 'text' | 'markdown' | 'html' | null
+  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'markdown', nullable: true })
+  bodyType?: 'markdown' | null
 
   /**
    * User or process that created this version

--- a/backend/src/api/templates/entities/template.entity.ts
+++ b/backend/src/api/templates/entities/template.entity.ts
@@ -100,11 +100,11 @@ export class Template {
   engine: TemplateEngineCode
 
   /**
-   * Body content type: 'text' (plain), 'markdown' (markdown→HTML), 'html' (raw HTML)
+   * Body content type: 'markdown' (markdown→HTML)
    * Determines rendering behavior during template rendering
    */
-  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'html', nullable: true })
-  bodyType?: 'text' | 'markdown' | 'html' | null
+  @Column({ name: 'body_type', type: 'varchar', length: 20, default: 'markdown', nullable: true })
+  bodyType?: 'markdown' | null
 
   /**
    * Current version number

--- a/backend/src/api/templates/schemas/create-template.dto.ts
+++ b/backend/src/api/templates/schemas/create-template.dto.ts
@@ -61,11 +61,11 @@ export class CreateTemplateDto {
   engineCode?: TemplateEngine
 
   /**
-   * Body content type for rendering: text (plain), markdown (markdown→HTML), html (raw HTML)
-   * Optional for MJML templates
+   * Body content type for rendering: markdown (markdown→HTML)
+   * Optional for MJML templates; ignored when engineCode is MJML
    * @example "markdown"
    */
   @IsOptional()
-  @IsEnum(['text', 'markdown', 'html'])
-  bodyType?: 'text' | 'markdown' | 'html'
+  @IsEnum(['markdown'])
+  bodyType?: 'markdown'
 }

--- a/backend/src/api/templates/schemas/template-response.dto.ts
+++ b/backend/src/api/templates/schemas/template-response.dto.ts
@@ -43,9 +43,9 @@ export class TemplateResponseDto {
 
   /**
    * Body content type
-   * @example "html"
+   * @example "markdown"
    */
-  bodyType?: 'text' | 'markdown' | 'html'
+  bodyType?: 'markdown'
 
   /**
    * Template rendering engine

--- a/backend/src/api/templates/schemas/update-template.dto.ts
+++ b/backend/src/api/templates/schemas/update-template.dto.ts
@@ -58,10 +58,10 @@ export class UpdateTemplateDto extends PartialType(CreateTemplateDto) {
 
   /**
    * Body content type for rendering
-   * Optional for MJML templates
-   * @example "html"
+   * Optional for MJML templates; ignored when engineCode is MJML
+   * @example "markdown"
    */
   @IsOptional()
-  @IsEnum(['text', 'markdown', 'html'])
-  bodyType?: 'text' | 'markdown' | 'html'
+  @IsEnum(['markdown'])
+  bodyType?: 'markdown'
 }

--- a/backend/src/api/templates/templates.controller.spec.ts
+++ b/backend/src/api/templates/templates.controller.spec.ts
@@ -39,7 +39,7 @@ describe('TemplatesController', () => {
     subject: 'Welcome {{name}}',
     body: 'Hello {{name}}!',
     engineCode: TemplateEngine.HANDLEBARS,
-    bodyType: 'html',
+    bodyType: 'markdown',
     version: 1,
     active: true,
     createdBy: 'user-123',
@@ -298,7 +298,7 @@ describe('TemplatesController', () => {
         subject: 'Subject',
         body: 'Body',
         engineCode: TemplateEngine.HANDLEBARS,
-        bodyType: 'html',
+        bodyType: 'markdown',
       }
 
       mockTemplatesService.createTemplate.mockResolvedValue(mockTemplate)
@@ -560,7 +560,7 @@ describe('TemplatesController', () => {
       const previewResult = {
         subject: 'Welcome Jane',
         body: 'Hello Jane Doe!',
-        bodyType: 'html',
+        bodyType: 'markdown',
       }
 
       mockTemplatesService.previewTemplate.mockResolvedValue(previewResult)
@@ -573,7 +573,7 @@ describe('TemplatesController', () => {
 
       expect(result.subject).toBe('Welcome Jane')
       expect(result.body).toBe('Hello Jane Doe!')
-      expect(result.bodyType).toBe('html')
+      expect(result.bodyType).toBe('markdown')
     })
 
     it('should throw error when template not found', async () => {

--- a/backend/src/api/templates/templates.repository.spec.ts
+++ b/backend/src/api/templates/templates.repository.spec.ts
@@ -20,7 +20,7 @@ describe('TemplatesRepository', () => {
     subject: 'Welcome to {{siteName}}!',
     body: 'Hello {{userName}}, welcome!',
     engineCode: TemplateEngine.HANDLEBARS,
-    bodyType: 'html',
+    bodyType: 'markdown',
     version: 1,
     active: true,
     createdBy: 'user-123',
@@ -35,7 +35,7 @@ describe('TemplatesRepository', () => {
     version: 1,
     subject: 'Welcome to {{siteName}}!',
     body: 'Hello {{userName}}, welcome!',
-    bodyType: 'html',
+    bodyType: 'markdown',
     createdBy: 'user-123',
     createdAt: new Date(),
   } as TemplateVersion
@@ -470,7 +470,7 @@ describe('TemplatesRepository', () => {
         version: 2,
         subject: 'Subject',
         body: 'Body',
-        bodyType: 'html',
+        bodyType: 'markdown',
       }
 
       mockVersionRepository.create.mockReturnValue(mockTemplateVersion)

--- a/backend/src/api/templates/templates.service.spec.ts
+++ b/backend/src/api/templates/templates.service.spec.ts
@@ -20,7 +20,7 @@ describe('TemplatesService', () => {
     subject: 'Welcome to {{siteName}}!',
     body: 'Hello {{userName}}, welcome!',
     engineCode: TemplateEngine.HANDLEBARS,
-    bodyType: 'html',
+    bodyType: 'markdown',
     version: 1,
     active: true,
     createdBy: 'user-123',
@@ -59,6 +59,7 @@ describe('TemplatesService', () => {
     subject: undefined,
     body: 'Your code is {{code}}',
     engineCode: TemplateEngine.MJML,
+    bodyType: null,
   }
 
   const mockRepository = {
@@ -99,7 +100,7 @@ describe('TemplatesService', () => {
   })
 
   describe('renderTemplateContent', () => {
-    it('should render template and return with bodyType', async () => {
+    it('should render template and return with markdown bodyType', async () => {
       const result = await service.renderTemplateContent(mockTemplate, {
         userName: 'John',
         siteName: 'MyApp',
@@ -107,7 +108,7 @@ describe('TemplatesService', () => {
 
       expect(result.subject).toBe('Welcome to MyApp!')
       expect(result.body).toBe('Hello John, welcome!')
-      expect(result.bodyType).toBe('html')
+      expect(result.bodyType).toBe('markdown')
     })
 
     it('should fall back to html when stored MJML bodyType is null', async () => {
@@ -273,7 +274,7 @@ describe('TemplatesService', () => {
       )
     })
 
-    it('should default bodyType to html if not provided', async () => {
+    it('should default bodyType to markdown if not provided', async () => {
       const createDto = {
         name: 'Test Template',
         description: 'Test',
@@ -286,7 +287,7 @@ describe('TemplatesService', () => {
       mockRepository.create.mockResolvedValue({
         ...mockTemplate,
         ...createDto,
-        bodyType: 'html',
+        bodyType: 'markdown',
       })
       mockRepository.createVersion.mockResolvedValue({})
 
@@ -294,7 +295,7 @@ describe('TemplatesService', () => {
 
       expect(mockRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          bodyType: 'html',
+          bodyType: 'markdown',
         }),
       )
     })

--- a/backend/src/api/templates/templates.service.ts
+++ b/backend/src/api/templates/templates.service.ts
@@ -5,7 +5,6 @@ import {
   ConflictException,
   Inject,
 } from '@nestjs/common'
-import MarkdownIt from 'markdown-it'
 import { Template } from './entities/template.entity'
 import { TemplateEngine } from '../../enum/template-engine.enum'
 import { NotificationChannel } from '../../enum/notification-channel.enum'
@@ -27,21 +26,12 @@ import type { ParsedListQuery } from '../../common/query/list-query.types'
  */
 @Injectable()
 export class TemplatesService {
-  private readonly markdown: MarkdownIt
-
   constructor(
     private readonly templatesRepository: TemplatesRepository,
     @Inject(TEMPLATE_RENDERER_REGISTRY_TOKEN)
     private readonly rendererRegistry: ITemplateRendererRegistry,
     private readonly tenantsService: TenantsService,
-  ) {
-    // Initialize markdown-it with safe defaults
-    this.markdown = new MarkdownIt({
-      html: true,
-      linkify: true,
-      typographer: false,
-    })
-  }
+  ) {}
 
   /**
    * List all active templates for a tenant
@@ -101,7 +91,7 @@ export class TemplatesService {
     }
 
     const engineCode = createDto.engineCode || TemplateEngine.HANDLEBARS
-    const bodyType = engineCode === TemplateEngine.MJML ? null : (createDto.bodyType ?? 'html')
+    const bodyType = engineCode === TemplateEngine.MJML ? null : 'markdown'
 
     const template = await this.templatesRepository.create({
       tenantId,
@@ -181,7 +171,7 @@ export class TemplatesService {
     if (nextEngineCode === TemplateEngine.MJML) {
       template.bodyType = null
     } else {
-      template.bodyType = updateDto.bodyType ?? template.bodyType ?? 'html'
+      template.bodyType = updateDto.bodyType ?? template.bodyType ?? 'markdown'
     }
     template.updatedBy = userId
 
@@ -237,14 +227,14 @@ export class TemplatesService {
    * Returns raw body with bodyType flag - adapter will handle format conversion
    * @param template The template to render
    * @param personalisation The data to use for rendering (e.g., request.params)
-   * @param bodyType Optional override for body content type (text, markdown, html)
+   * @param bodyType Optional override for body content type
    * @returns Object with rendered subject, body, and bodyType
    */
   public async renderTemplateContent(
     template: Template,
     personalisation: Record<string, any> = {},
-    bodyType?: 'text' | 'markdown' | 'html',
-  ): Promise<{ subject?: string; body: string; bodyType: 'text' | 'markdown' | 'html' }> {
+    bodyType?: 'markdown',
+  ): Promise<{ subject?: string; body: string; bodyType: 'markdown' | 'html' }> {
     // Convert all personalisation values to strings for template rendering
     const stringPersonalisation: Record<string, string> = {}
     for (const [key, value] of Object.entries(personalisation)) {
@@ -282,7 +272,10 @@ export class TemplatesService {
     const rendered = await renderer.renderEmail(renderContext)
 
     // Use provided bodyType or fall back to template's bodyType setting
-    const effectiveBodyType = bodyType ?? template.bodyType ?? 'html'
+    const effectiveBodyType =
+      bodyType ??
+      template.bodyType ??
+      (template.engineCode === TemplateEngine.MJML ? 'html' : 'markdown')
 
     // Return rendered content with bodyType flag for adapter to process
     return {
@@ -321,20 +314,6 @@ export class TemplatesService {
         return 'sms'
       default:
         return 'email' // default fallback
-    }
-  }
-
-  /**
-   * Render markdown to HTML
-   * Converts markdown-formatted text to HTML
-   * @param markdown The markdown text to convert
-   * @returns HTML-formatted text
-   */
-  private renderMarkdown(markdown: string): string {
-    try {
-      return this.markdown.render(markdown)
-    } catch (error) {
-      throw new BadRequestException(`Markdown rendering error: ${(error as Error).message}`)
     }
   }
 

--- a/backend/src/queue/workers/email-delivery.worker.ts
+++ b/backend/src/queue/workers/email-delivery.worker.ts
@@ -35,6 +35,16 @@ type ResolvedEmailDeliveryPayload = Omit<NotifyEmailChannel, 'attachments'> & {
 export class EmailDeliveryWorker {
   private readonly logger = new Logger(EmailDeliveryWorker.name)
 
+  private static normalizeTemplateBodyType(
+    bodyType: 'text' | 'markdown' | 'html' | undefined,
+  ): 'markdown' | undefined {
+    if (bodyType === 'markdown' || bodyType === 'text') {
+      return 'markdown'
+    }
+
+    return undefined
+  }
+
   private static hasAttachmentReferences(
     attachments: unknown,
   ): attachments is NonNullable<ProcessedNotifyEmailChannel['attachments']> {
@@ -155,11 +165,11 @@ export class EmailDeliveryWorker {
             // Merge template content into email payload if channel matches
             if (template.channelCode === 'EMAIL') {
               // Render the template with personalisation data from request.params
-              // Use request's bodyType if provided, otherwise template's default
+              // Normalize legacy body types before entering the markdown-only render path.
               const rendered = await templatesService.renderTemplateContent(
                 template,
                 request.params || {},
-                emailPayload.content?.bodyType,
+                EmailDeliveryWorker.normalizeTemplateBodyType(emailPayload.content?.bodyType),
               )
 
               emailPayload = {

--- a/backend/src/queue/workers/sms-delivery.worker.ts
+++ b/backend/src/queue/workers/sms-delivery.worker.ts
@@ -27,6 +27,16 @@ import { ISmsTransport } from '../../adapters'
 export class SmsDeliveryWorker {
   private readonly logger = new Logger(SmsDeliveryWorker.name)
 
+  private static normalizeTemplateBodyType(
+    bodyType: 'text' | 'markdown' | 'html' | undefined,
+  ): 'markdown' | undefined {
+    if (bodyType === 'markdown' || bodyType === 'text') {
+      return 'markdown'
+    }
+
+    return undefined
+  }
+
   /**
    * Initialize the SMS delivery worker on a queue
    * @param smsQueue The BullMQ queue instance for SMS delivery jobs
@@ -92,11 +102,11 @@ export class SmsDeliveryWorker {
             // Merge template content into SMS payload if channel matches
             if (template.channelCode === 'SMS') {
               // Render the template with personalisation data from request.params
-              // Use request's bodyType if provided, otherwise template's default
+              // Normalize legacy body types before entering the markdown-only render path.
               const rendered = await templatesService.renderTemplateContent(
                 template,
                 request.params || {},
-                payload.content?.bodyType,
+                SmsDeliveryWorker.normalizeTemplateBodyType(payload.content?.bodyType),
               )
 
               resolvedPayload = {

--- a/frontend/src/api/templates.api.ts
+++ b/frontend/src/api/templates.api.ts
@@ -15,7 +15,6 @@ export enum TemplateEngine {
 }
 
 export enum TemplateBodyType {
-  HTML = 'html',
   MARKDOWN = 'markdown',
 }
 

--- a/frontend/src/pages/templates/TemplateCreate.spec.tsx
+++ b/frontend/src/pages/templates/TemplateCreate.spec.tsx
@@ -134,12 +134,8 @@ describe('TemplateCreate', () => {
     createTemplateMock.mockResolvedValue({})
   })
 
-  it('hides body type when MJML is selected', () => {
+  it('does not show body type choices', () => {
     render(<TemplateCreate />)
-
-    expect(screen.getByText('Body type')).toBeTruthy()
-
-    fireEvent.click(screen.getByLabelText('MJML'))
 
     expect(screen.queryByText('Body type')).toBeNull()
   })
@@ -177,6 +173,39 @@ describe('TemplateCreate', () => {
       engineCode: 'mjml',
       subject: 'Hello {{name}}',
       body: '<mjml><mj-body><mj-section><mj-column><mj-text>Hello {{name}}</mj-text></mj-column></mj-section></mj-body></mjml>',
+    })
+  })
+
+  it('does not send bodyType when saving a non-MJML template', async () => {
+    render(<TemplateCreate />)
+
+    fireEvent.click(screen.getByLabelText('Email'))
+    fireEvent.click(screen.getByLabelText('Handlebars'))
+
+    const [titleInput, subjectInput, bodyTextarea] = screen.getAllByRole('textbox')
+
+    fireEvent.change(titleInput, {
+      target: { value: 'welcome template' },
+    })
+    fireEvent.change(subjectInput, {
+      target: { value: 'Welcome {{name}}' },
+    })
+    fireEvent.change(bodyTextarea, {
+      target: { value: '# Hello {{name}}' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(createTemplateMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(createTemplateMock).toHaveBeenCalledWith({
+      name: 'welcome template',
+      channelCode: 'EMAIL',
+      engineCode: 'handlebars',
+      subject: 'Welcome {{name}}',
+      body: '# Hello {{name}}',
     })
   })
 })

--- a/frontend/src/pages/templates/TemplateCreate.tsx
+++ b/frontend/src/pages/templates/TemplateCreate.tsx
@@ -2,12 +2,7 @@ import { useState } from 'react'
 import type { FC } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { Button, TextField, RadioGroup, Radio } from '@bcgov/design-system-react-components'
-import {
-  createTemplate,
-  NotificationChannel,
-  TemplateEngine,
-  TemplateBodyType,
-} from '@/api/templates.api'
+import { createTemplate, NotificationChannel, TemplateEngine } from '@/api/templates.api'
 import { showErrorToast, showSuccessToast } from '@/redux/utils/toastUtils'
 import PageHeading from '@/components/PageHeading'
 import '@/scss/components/templates.scss'
@@ -19,7 +14,6 @@ const TemplateCreate: FC = () => {
     name: '',
     channelCode: '' as string,
     engineCode: '' as string,
-    bodyType: '' as string,
     subject: '',
     body: '',
   })
@@ -27,13 +21,11 @@ const TemplateCreate: FC = () => {
     name: '',
     channelCode: '',
     engineCode: '',
-    bodyType: '',
     subject: '',
     body: '',
   })
 
   const isSaveDisabled = saving || !formData.name.trim()
-  const isMjml = formData.engineCode === TemplateEngine.MJML
 
   const handleFieldChange = (field: string) => (value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
@@ -45,7 +37,6 @@ const TemplateCreate: FC = () => {
       name: '',
       channelCode: '',
       engineCode: '',
-      bodyType: '',
       subject: '',
       body: '',
     }
@@ -57,9 +48,6 @@ const TemplateCreate: FC = () => {
     }
     if (!formData.engineCode) {
       errors.engineCode = 'Please select an option to continue.'
-    }
-    if (!isMjml && !formData.bodyType) {
-      errors.bodyType = 'Please select an option to continue.'
     }
     if (formData.channelCode === NotificationChannel.EMAIL && !formData.subject.trim()) {
       errors.subject = ' '
@@ -82,9 +70,6 @@ const TemplateCreate: FC = () => {
         engineCode: formData.engineCode as TemplateEngine,
         subject: formData.channelCode === NotificationChannel.EMAIL ? formData.subject : undefined,
         body: formData.body,
-        ...(!isMjml && formData.bodyType
-          ? { bodyType: formData.bodyType as TemplateBodyType }
-          : {}),
       })
       showSuccessToast('Template created successfully')
       navigate({ to: '/templates' })
@@ -166,12 +151,10 @@ const TemplateCreate: FC = () => {
                 setFormData((prev) => ({
                   ...prev,
                   engineCode: value,
-                  bodyType: value === TemplateEngine.MJML ? '' : prev.bodyType,
                 }))
                 setFormErrors((prev) => ({
                   ...prev,
                   engineCode: '',
-                  bodyType: '',
                 }))
               }}
               isInvalid={!!formErrors.engineCode}
@@ -191,34 +174,6 @@ const TemplateCreate: FC = () => {
               </Radio>
             </RadioGroup>
           </div>
-
-          {!isMjml && (
-            <div className="mb-4 error-after-label">
-              <RadioGroup
-                label={
-                  (
-                    <>
-                      <strong>Body type</strong> (required)
-                    </>
-                  ) as any
-                }
-                value={formData.bodyType}
-                onChange={(value) => {
-                  setFormData((prev) => ({ ...prev, bodyType: value }))
-                  setFormErrors((prev) => ({ ...prev, bodyType: '' }))
-                }}
-                isInvalid={!!formErrors.bodyType}
-                errorMessage={formErrors.bodyType}
-              >
-                <Radio key="html" value={TemplateBodyType.HTML}>
-                  HTML
-                </Radio>
-                <Radio key="markdown" value={TemplateBodyType.MARKDOWN}>
-                  Markdown
-                </Radio>
-              </RadioGroup>
-            </div>
-          )}
 
           {formData.channelCode === NotificationChannel.EMAIL && (
             <div className="mb-4 desc-above">

--- a/frontend/src/pages/templates/TemplateEdit.spec.tsx
+++ b/frontend/src/pages/templates/TemplateEdit.spec.tsx
@@ -135,7 +135,7 @@ const template = {
   name: 'Welcome Template',
   channelCode: 'EMAIL',
   engineCode: 'handlebars',
-  bodyType: 'html',
+  bodyType: 'markdown',
   subject: 'Hello {{name}}',
   body: 'Hello {{name}}',
   version: 1,
@@ -153,12 +153,8 @@ describe('TemplateEdit', () => {
     updateTemplateMock.mockResolvedValue({})
   })
 
-  it('hides body type when the loaded template engine is MJML', async () => {
-    getTemplateByIdMock.mockResolvedValue({
-      ...template,
-      engineCode: 'mjml',
-      bodyType: undefined,
-    })
+  it('does not show body type choices', async () => {
+    getTemplateByIdMock.mockResolvedValue(template)
 
     render(<TemplateEdit templateId="template-123" />)
 
@@ -195,6 +191,31 @@ describe('TemplateEdit', () => {
       engineCode: 'mjml',
       subject: 'Hello {{name}}',
       body: '<mjml><mj-body><mj-section><mj-column><mj-text>Hello {{name}}</mj-text></mj-column></mj-section></mj-body></mjml>',
+    })
+  })
+
+  it('does not send bodyType when saving a non-MJML template', async () => {
+    render(<TemplateEdit templateId="template-123" />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Welcome Template')).toBeTruthy()
+    })
+
+    fireEvent.change(screen.getByLabelText('Template body (required)'), {
+      target: { value: '# Updated {{name}}' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(updateTemplateMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(updateTemplateMock).toHaveBeenCalledWith('template-123', {
+      name: 'Welcome Template',
+      engineCode: 'handlebars',
+      subject: 'Hello {{name}}',
+      body: '# Updated {{name}}',
     })
   })
 })

--- a/frontend/src/pages/templates/TemplateEdit.tsx
+++ b/frontend/src/pages/templates/TemplateEdit.tsx
@@ -7,7 +7,6 @@ import {
   updateTemplate,
   NotificationChannel,
   TemplateEngine,
-  TemplateBodyType,
 } from '@/api/templates.api'
 import type { TemplateResponse } from '@/api/templates.api'
 import { showErrorToast, showSuccessToast } from '@/redux/utils/toastUtils'
@@ -27,18 +26,15 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
     name: '',
     channelCode: NotificationChannel.EMAIL as string,
     engineCode: TemplateEngine.HANDLEBARS as string,
-    bodyType: '' as string,
     subject: '',
     body: '',
   })
   const [formErrors, setFormErrors] = useState({
     name: '',
     engineCode: '',
-    bodyType: '',
     subject: '',
     body: '',
   })
-  const isMjml = formData.engineCode === TemplateEngine.MJML
 
   useEffect(() => {
     const fetchTemplate = async () => {
@@ -50,7 +46,6 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
           name: data.name,
           channelCode: data.channelCode,
           engineCode: data.engineCode,
-          bodyType: data.bodyType || '',
           subject: data.subject || '',
           body: data.body || '',
         })
@@ -70,15 +65,12 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
   }
 
   const validate = (): boolean => {
-    const errors = { name: '', engineCode: '', bodyType: '', subject: '', body: '' }
+    const errors = { name: '', engineCode: '', subject: '', body: '' }
     if (!formData.name.trim()) {
       errors.name = ' '
     }
     if (!formData.engineCode) {
       errors.engineCode = 'Please select an option to continue.'
-    }
-    if (!isMjml && !formData.bodyType) {
-      errors.bodyType = 'Please select an option to continue.'
     }
     if (formData.channelCode === NotificationChannel.EMAIL && !formData.subject.trim()) {
       errors.subject = ' '
@@ -100,9 +92,6 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
         engineCode: formData.engineCode as TemplateEngine,
         subject: formData.channelCode === NotificationChannel.EMAIL ? formData.subject : undefined,
         body: formData.body,
-        ...(!isMjml && formData.bodyType
-          ? { bodyType: formData.bodyType as TemplateBodyType }
-          : {}),
       })
       showSuccessToast('Template saved successfully')
       navigate({ to: '/templates' })
@@ -193,9 +182,8 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
                 setFormData((prev) => ({
                   ...prev,
                   engineCode: value,
-                  bodyType: value === TemplateEngine.MJML ? '' : prev.bodyType,
                 }))
-                setFormErrors((prev) => ({ ...prev, engineCode: '', bodyType: '' }))
+                setFormErrors((prev) => ({ ...prev, engineCode: '' }))
               }}
               isInvalid={!!formErrors.engineCode}
               errorMessage={formErrors.engineCode}
@@ -214,34 +202,6 @@ const TemplateEdit: FC<TemplateEditProps> = ({ templateId }) => {
               </Radio>
             </RadioGroup>
           </div>
-
-          {!isMjml && (
-            <div className="mb-4 error-after-label">
-              <RadioGroup
-                label={
-                  (
-                    <>
-                      <strong>Body type</strong> (required)
-                    </>
-                  ) as any
-                }
-                value={formData.bodyType}
-                onChange={(value) => {
-                  setFormData((prev) => ({ ...prev, bodyType: value }))
-                  setFormErrors((prev) => ({ ...prev, bodyType: '' }))
-                }}
-                isInvalid={!!formErrors.bodyType}
-                errorMessage={formErrors.bodyType}
-              >
-                <Radio key="html" value={TemplateBodyType.HTML}>
-                  HTML
-                </Radio>
-                <Radio key="markdown" value={TemplateBodyType.MARKDOWN}>
-                  Markdown
-                </Radio>
-              </RadioGroup>
-            </div>
-          )}
 
           {formData.channelCode === NotificationChannel.EMAIL && (
             <div className="mb-4 desc-above">

--- a/migrations/sql/V39__default_template_body_type_to_markdown.sql
+++ b/migrations/sql/V39__default_template_body_type_to_markdown.sql
@@ -1,0 +1,13 @@
+ALTER TABLE notify.template
+ALTER COLUMN body_type SET DEFAULT 'markdown';
+
+UPDATE notify.template
+SET body_type = 'markdown'
+WHERE body_type = 'html';
+
+ALTER TABLE notify.template_version
+ALTER COLUMN body_type SET DEFAULT 'markdown';
+
+UPDATE notify.template_version
+SET body_type = 'markdown'
+WHERE body_type = 'html';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

The Body type selection has been removed from the template create/edit UI. Non-MJML templates now default to Markdown automatically, while MJML remains unchanged and continues to omit bodyType.

What changed
Removed the Body type radio group from template create/edit screens.
Defaulted non-MJML templates to Markdown.
Kept MJML behavior unchanged with bodyType omitted/null.
Updated backend create/update validation so bodyType: html is no longer accepted.
Updated backend defaults from html to markdown.
Added a migration to change template body type defaults to markdown.
Migrated existing body_type = 'html' rows to markdown.
Disabled raw HTML rendering in Markdown email delivery by using MarkdownIt({ html: false }) in the CHES adapter.
Updated frontend and backend tests for the new Markdown-by-default behavior.

Fixes # CCP-4982

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-143.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-143.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)