### PR TITLE
feat: CCP-4958 adding tenant settings page for alert email address

### DIFF
--- a/api-gateway/templates/routes.yaml
+++ b/api-gateway/templates/routes.yaml
@@ -856,6 +856,23 @@ routes:
     request_buffering: true
     response_buffering: true
 
+  # /api/v1/frontend/tenant-settings (frontend variant)
+  # Called by the Notify web app with a frontend user JWT (never a service API key).
+  - name: ${ROUTE_PREFIX}tenant-settings-frontend
+    tags: [ns.${GATEWAY_ID}.${ENVIRONMENT}]
+    hosts:
+      - ${GATEWAY_HOSTNAME}
+    paths:
+      - ${PATH_PREFIX}/api/v1/frontend/tenant-settings
+    methods:
+      - GET
+      - PATCH
+    strip_path: true
+    https_redirect_status_code: 426
+    path_handling: v0
+    request_buffering: true
+    response_buffering: true
+
   # /api/v1/frontend/admin/api-key-usage (admin variant - all tenants' usage)
   # Admin-only (NOTIFY_ADMIN SSO role), not tenant-scoped. Same jwt-keycloak plugin
   # as the other frontend admin routes. Kong prefix-matches, so PATCH also covers
@@ -1912,6 +1929,34 @@ plugins:
     tags: [ns.${GATEWAY_ID}.${ENVIRONMENT}]
     enabled: true
     route: ${ROUTE_PREFIX}api-key-usage-frontend
+    config:
+      allowed_iss:
+        - ${FRONTEND_KEYCLOAK_ISSUER}
+      allowed_aud: ${FRONTEND_ALLOWED_AUDIENCE}
+      run_on_preflight: true
+      iss_key_grace_period: 10
+      maximum_expiration: 0
+      algorithm: RS256
+      claims_to_verify:
+        - exp
+      uri_param_names:
+        - jwt
+      cookie_names: []
+      scope: null
+      roles: null
+      realm_roles: null
+      client_roles: null
+      anonymous: null
+      consumer_match: true
+      consumer_match_claim: azp
+      consumer_match_claim_custom_id: true
+      consumer_match_ignore_not_found: true
+
+  # Tenant Settings Frontend - Frontend Token
+  - name: jwt-keycloak
+    tags: [ns.${GATEWAY_ID}.${ENVIRONMENT}]
+    enabled: true
+    route: ${ROUTE_PREFIX}tenant-settings-frontend
     config:
       allowed_iss:
         - ${FRONTEND_KEYCLOAK_ISSUER}

--- a/backend/src/api/api.module.ts
+++ b/backend/src/api/api.module.ts
@@ -5,6 +5,7 @@ import { TemplatesModule } from './templates/templates.module'
 import { AuthModule } from './auth/auth.module'
 import { ApiKeysModule } from './api-keys/api-keys.module'
 import { AttachmentModule } from './attachment/attachment.module'
+import { TenantSettingsModule } from './tenant-settings/tenant-settings.module'
 
 /**
  * API Module
@@ -28,6 +29,7 @@ import { AttachmentModule } from './attachment/attachment.module'
     AuthModule,
     ApiKeysModule,
     AttachmentModule,
+    TenantSettingsModule,
   ],
   exports: [
     NotifyModule,
@@ -36,6 +38,7 @@ import { AttachmentModule } from './attachment/attachment.module'
     AuthModule,
     ApiKeysModule,
     AttachmentModule,
+    TenantSettingsModule,
   ],
 })
 export class ApiModule {}

--- a/backend/src/api/tenant-settings/entities/tenant-settings.entity.ts
+++ b/backend/src/api/tenant-settings/entities/tenant-settings.entity.ts
@@ -8,19 +8,19 @@ export class TenantSettings {
   @Column({ type: 'uuid', name: 'tenant_id' })
   tenantId: string
 
-  @Column({ nullable: true, length: 320, name: 'alert_email' })
+  @Column({ type: 'varchar', nullable: true, length: 320, name: 'alert_email' })
   alertEmail: string | null
 
   @Column({ name: 'created_at' })
   createdAt: Date
 
-  @Column({ nullable: true, name: 'created_by' })
+  @Column({ type: 'varchar', nullable: true, length: 200, name: 'created_by' })
   createdBy: string | null
 
   @Column({ name: 'updated_at' })
   updatedAt: Date
 
-  @Column({ nullable: true, name: 'updated_by' })
+  @Column({ type: 'varchar', nullable: true, length: 200, name: 'updated_by' })
   updatedBy: string | null
 
   @Column({ default: false, name: 'is_deleted' })

--- a/backend/src/api/tenant-settings/entities/tenant-settings.entity.ts
+++ b/backend/src/api/tenant-settings/entities/tenant-settings.entity.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+
+@Entity('tenant_settings')
+export class TenantSettings {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ type: 'uuid', name: 'tenant_id' })
+  tenantId: string
+
+  @Column({ nullable: true, length: 320, name: 'alert_email' })
+  alertEmail: string | null
+
+  @Column({ name: 'created_at' })
+  createdAt: Date
+
+  @Column({ nullable: true, name: 'created_by' })
+  createdBy: string | null
+
+  @Column({ name: 'updated_at' })
+  updatedAt: Date
+
+  @Column({ nullable: true, name: 'updated_by' })
+  updatedBy: string | null
+
+  @Column({ default: false, name: 'is_deleted' })
+  isDeleted: boolean
+}

--- a/backend/src/api/tenant-settings/schemas/update-tenant-settings.dto.ts
+++ b/backend/src/api/tenant-settings/schemas/update-tenant-settings.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, ValidateIf } from 'class-validator'
+import { ApiProperty } from '@nestjs/swagger'
+
+export class UpdateTenantSettingsDto {
+  @ApiProperty({
+    description: 'Email address that receives system and limit alerts for the tenant',
+    nullable: true,
+  })
+  @ValidateIf((_object, value) => value !== null)
+  @IsEmail()
+  alertEmail: string | null
+}

--- a/backend/src/api/tenant-settings/tenant-settings.controller.spec.ts
+++ b/backend/src/api/tenant-settings/tenant-settings.controller.spec.ts
@@ -1,0 +1,68 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants'
+import { Test, TestingModule } from '@nestjs/testing'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ROLES_KEY } from '../../common/decorators/roles.decorator'
+import { NotifyFrontendRoleGuard } from '../../common/guards/notify-frontend-role.guard'
+import { SsoRole } from '../../enum/sso-role.enum'
+import { TenantSettingsController } from './tenant-settings.controller'
+import { TenantSettingsService } from './tenant-settings.service'
+
+describe('TenantSettingsController', () => {
+  let controller: TenantSettingsController
+
+  const mockService = {
+    findByTenantId: vi.fn(),
+    upsert: vi.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TenantSettingsController],
+      providers: [{ provide: TenantSettingsService, useValue: mockService }],
+    })
+      .overrideGuard(NotifyFrontendRoleGuard)
+      .useValue({})
+      .compile()
+
+    controller = module.get(TenantSettingsController)
+    vi.clearAllMocks()
+  })
+
+  it.each(['getSettings', 'updateSettings'] as const)(
+    'requires the global NOTIFY_ADMIN role for %s',
+    (methodName) => {
+      const roles = Reflect.getMetadata(ROLES_KEY, TenantSettingsController.prototype[methodName])
+
+      expect(roles).toEqual([SsoRole.NOTIFY_ADMIN])
+      expect(roles).not.toContain('NOTIFY_OPERATIONS_ADMIN')
+    },
+  )
+
+  it('uses the tenant resolved by the guard for GET', async () => {
+    const settings = { alertEmail: 'alerts@example.com' }
+    mockService.findByTenantId.mockResolvedValue(settings)
+
+    await expect(controller.getSettings({ tenant: { id: 'tenant-1' } } as any)).resolves.toBe(
+      settings,
+    )
+    expect(mockService.findByTenantId).toHaveBeenCalledWith('tenant-1')
+  })
+
+  it('uses the resolved tenant and user for PATCH', async () => {
+    const settings = { alertEmail: null }
+    mockService.upsert.mockResolvedValue(settings)
+
+    await expect(
+      controller.updateSettings({ tenant: { id: 'tenant-1' }, userGuid: 'user-1' } as any, {
+        alertEmail: null,
+      }),
+    ).resolves.toBe(settings)
+    expect(mockService.upsert).toHaveBeenCalledWith('tenant-1', null, 'user-1')
+  })
+
+  it('retains the tenant-aware frontend guard', () => {
+    expect(Reflect.getMetadata(GUARDS_METADATA, TenantSettingsController)).toEqual([
+      NotifyFrontendRoleGuard,
+    ])
+  })
+})

--- a/backend/src/api/tenant-settings/tenant-settings.controller.ts
+++ b/backend/src/api/tenant-settings/tenant-settings.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, Patch, Req, Request, UseGuards, Version } from '
 import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Roles } from '../../common/decorators/roles.decorator'
 import { NotifyFrontendRoleGuard } from '../../common/guards/notify-frontend-role.guard'
-import { CstarRole as CstarRoleEnum } from '../../enum/cstar-role.enum'
+import { SsoRole } from '../../enum/sso-role.enum'
 import type { Tenant } from '../admin/tenants/entities/tenant.entity'
 import { TenantSettings } from './entities/tenant-settings.entity'
 import { UpdateTenantSettingsDto } from './schemas/update-tenant-settings.dto'
@@ -17,11 +17,7 @@ export class TenantSettingsController {
 
   @Version('1')
   @Get()
-  @Roles(
-    CstarRoleEnum.NOTIFY_VIEWER,
-    CstarRoleEnum.NOTIFY_TEMPLATE_EDITOR,
-    CstarRoleEnum.NOTIFY_OPERATIONS_ADMIN,
-  )
+  @Roles(SsoRole.NOTIFY_ADMIN)
   @ApiOperation({ summary: 'Get settings for the authenticated tenant' })
   @ApiOkResponse({ type: TenantSettings })
   getSettings(@Req() req: Request): Promise<TenantSettings | null> {
@@ -31,7 +27,7 @@ export class TenantSettingsController {
 
   @Version('1')
   @Patch()
-  @Roles(CstarRoleEnum.NOTIFY_OPERATIONS_ADMIN)
+  @Roles(SsoRole.NOTIFY_ADMIN)
   @ApiOperation({ summary: 'Update settings for the authenticated tenant' })
   @ApiOkResponse({ type: TenantSettings })
   updateSettings(

--- a/backend/src/api/tenant-settings/tenant-settings.controller.ts
+++ b/backend/src/api/tenant-settings/tenant-settings.controller.ts
@@ -1,0 +1,45 @@
+import { Body, Controller, Get, Patch, Req, Request, UseGuards, Version } from '@nestjs/common'
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger'
+import { Roles } from '../../common/decorators/roles.decorator'
+import { NotifyFrontendRoleGuard } from '../../common/guards/notify-frontend-role.guard'
+import { CstarRole as CstarRoleEnum } from '../../enum/cstar-role.enum'
+import type { Tenant } from '../admin/tenants/entities/tenant.entity'
+import { TenantSettings } from './entities/tenant-settings.entity'
+import { UpdateTenantSettingsDto } from './schemas/update-tenant-settings.dto'
+import { TenantSettingsService } from './tenant-settings.service'
+
+@ApiTags('tenant-settings')
+@Controller('frontend/tenant-settings')
+@UseGuards(NotifyFrontendRoleGuard)
+@ApiBearerAuth()
+export class TenantSettingsController {
+  constructor(private readonly tenantSettingsService: TenantSettingsService) {}
+
+  @Version('1')
+  @Get()
+  @Roles(
+    CstarRoleEnum.NOTIFY_VIEWER,
+    CstarRoleEnum.NOTIFY_TEMPLATE_EDITOR,
+    CstarRoleEnum.NOTIFY_OPERATIONS_ADMIN,
+  )
+  @ApiOperation({ summary: 'Get settings for the authenticated tenant' })
+  @ApiOkResponse({ type: TenantSettings })
+  getSettings(@Req() req: Request): Promise<TenantSettings | null> {
+    const tenant = (req as any).tenant as Tenant
+    return this.tenantSettingsService.findByTenantId(tenant.id)
+  }
+
+  @Version('1')
+  @Patch()
+  @Roles(CstarRoleEnum.NOTIFY_OPERATIONS_ADMIN)
+  @ApiOperation({ summary: 'Update settings for the authenticated tenant' })
+  @ApiOkResponse({ type: TenantSettings })
+  updateSettings(
+    @Req() req: Request,
+    @Body() dto: UpdateTenantSettingsDto,
+  ): Promise<TenantSettings> {
+    const tenant = (req as any).tenant as Tenant
+    const userGuid = (req as any).userGuid as string | undefined
+    return this.tenantSettingsService.upsert(tenant.id, dto.alertEmail, userGuid)
+  }
+}

--- a/backend/src/api/tenant-settings/tenant-settings.module.ts
+++ b/backend/src/api/tenant-settings/tenant-settings.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { CstarModule } from '../../services/cstar/cstar.module'
+import { TenantsModule } from '../admin/tenants/tenants.module'
+import { TenantSettings } from './entities/tenant-settings.entity'
+import { TenantSettingsController } from './tenant-settings.controller'
+import { TenantSettingsService } from './tenant-settings.service'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TenantSettings]), CstarModule, TenantsModule],
+  providers: [TenantSettingsService],
+  controllers: [TenantSettingsController],
+  exports: [TypeOrmModule, TenantSettingsService],
+})
+export class TenantSettingsModule {}

--- a/backend/src/api/tenant-settings/tenant-settings.service.spec.ts
+++ b/backend/src/api/tenant-settings/tenant-settings.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { vi } from 'vitest'
+import { TenantSettingsService } from './tenant-settings.service'
+import { TenantSettings } from './entities/tenant-settings.entity'
+
+describe('TenantSettingsService', () => {
+  let service: TenantSettingsService
+
+  const mockTenantSettings: TenantSettings = {
+    id: 'settings-uuid-1',
+    tenantId: 'tenant-uuid-1',
+    alertEmail: 'alerts@example.com',
+    createdAt: new Date(),
+    createdBy: 'creator-guid',
+    updatedAt: new Date(),
+    updatedBy: 'previous-updater-guid',
+    isDeleted: false,
+  }
+
+  const mockRepository = {
+    findOne: vi.fn(),
+    create: vi.fn(),
+    save: vi.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TenantSettingsService,
+        {
+          provide: getRepositoryToken(TenantSettings),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<TenantSettingsService>(TenantSettingsService)
+    vi.clearAllMocks()
+  })
+
+  describe('findByTenantId', () => {
+    it('should return tenant settings when they exist', async () => {
+      mockRepository.findOne.mockResolvedValue(mockTenantSettings)
+
+      const result = await service.findByTenantId('tenant-uuid-1')
+
+      expect(result).toEqual(mockTenantSettings)
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { tenantId: 'tenant-uuid-1' },
+      })
+    })
+
+    it('should return null when tenant settings do not exist', async () => {
+      mockRepository.findOne.mockResolvedValue(null)
+
+      const result = await service.findByTenantId('tenant-uuid-1')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('upsert', () => {
+    it('should create tenant settings with createdBy when none exist', async () => {
+      const createdSettings = {
+        ...mockTenantSettings,
+        alertEmail: 'new-alerts@example.com',
+        createdBy: 'updater-guid',
+      }
+      mockRepository.findOne.mockResolvedValue(null)
+      mockRepository.create.mockReturnValue(createdSettings)
+      mockRepository.save.mockResolvedValue(createdSettings)
+
+      const result = await service.upsert('tenant-uuid-1', 'new-alerts@example.com', 'updater-guid')
+
+      expect(mockRepository.create).toHaveBeenCalledWith({
+        tenantId: 'tenant-uuid-1',
+        alertEmail: 'new-alerts@example.com',
+        createdBy: 'updater-guid',
+      })
+      expect(mockRepository.save).toHaveBeenCalledWith(createdSettings)
+      expect(result).toEqual(createdSettings)
+    })
+
+    it('should update alertEmail and updatedBy when settings exist', async () => {
+      const existingSettings = { ...mockTenantSettings }
+      const savedSettings = {
+        ...existingSettings,
+        alertEmail: 'updated-alerts@example.com',
+        updatedBy: 'updater-guid',
+      }
+      mockRepository.findOne.mockResolvedValue(existingSettings)
+      mockRepository.save.mockResolvedValue(savedSettings)
+
+      const result = await service.upsert(
+        'tenant-uuid-1',
+        'updated-alerts@example.com',
+        'updater-guid',
+      )
+
+      expect(existingSettings.alertEmail).toBe('updated-alerts@example.com')
+      expect(existingSettings.updatedBy).toBe('updater-guid')
+      expect(mockRepository.save).toHaveBeenCalledWith(existingSettings)
+      expect(result).toEqual(savedSettings)
+    })
+
+    it('should clear alertEmail when it is set to null', async () => {
+      const existingSettings = { ...mockTenantSettings }
+      const savedSettings = { ...existingSettings, alertEmail: null, updatedBy: 'updater-guid' }
+      mockRepository.findOne.mockResolvedValue(existingSettings)
+      mockRepository.save.mockResolvedValue(savedSettings)
+
+      const result = await service.upsert('tenant-uuid-1', null, 'updater-guid')
+
+      expect(existingSettings.alertEmail).toBeNull()
+      expect(existingSettings.updatedBy).toBe('updater-guid')
+      expect(mockRepository.save).toHaveBeenCalledWith(existingSettings)
+      expect(result).toEqual(savedSettings)
+    })
+
+    it('should preserve existing updatedBy when updatedBy is omitted', async () => {
+      const existingSettings = { ...mockTenantSettings }
+      const savedSettings = { ...existingSettings, alertEmail: 'updated-alerts@example.com' }
+      mockRepository.findOne.mockResolvedValue(existingSettings)
+      mockRepository.save.mockResolvedValue(savedSettings)
+
+      const result = await service.upsert('tenant-uuid-1', 'updated-alerts@example.com')
+
+      expect(existingSettings.alertEmail).toBe('updated-alerts@example.com')
+      expect(existingSettings.updatedBy).toBe('previous-updater-guid')
+      expect(mockRepository.save).toHaveBeenCalledWith(existingSettings)
+      expect(result).toEqual(savedSettings)
+    })
+  })
+})

--- a/backend/src/api/tenant-settings/tenant-settings.service.ts
+++ b/backend/src/api/tenant-settings/tenant-settings.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { TenantSettings } from './entities/tenant-settings.entity'
+
+@Injectable()
+export class TenantSettingsService {
+  private readonly logger = new Logger(TenantSettingsService.name)
+
+  constructor(
+    @InjectRepository(TenantSettings)
+    private tenantSettingsRepository: Repository<TenantSettings>,
+  ) {}
+
+  async findByTenantId(tenantId: string): Promise<TenantSettings | null> {
+    return this.tenantSettingsRepository.findOne({ where: { tenantId } })
+  }
+
+  async upsert(
+    tenantId: string,
+    alertEmail: string | null,
+    updatedBy?: string,
+  ): Promise<TenantSettings> {
+    try {
+      const existing = await this.findByTenantId(tenantId)
+
+      if (existing) {
+        existing.alertEmail = alertEmail
+        existing.updatedBy = updatedBy ?? existing.updatedBy
+
+        const savedSettings = await this.tenantSettingsRepository.save(existing)
+        this.logger.debug(`Updated tenant settings for tenant: ${tenantId}`)
+        return savedSettings
+      }
+
+      const settings = this.tenantSettingsRepository.create({
+        tenantId,
+        alertEmail,
+        createdBy: updatedBy ?? null,
+      })
+
+      const savedSettings = await this.tenantSettingsRepository.save(settings)
+      this.logger.debug(`Created tenant settings for tenant: ${tenantId}`)
+      return savedSettings
+    } catch (error) {
+      this.logger.error(`Error upserting tenant settings for tenant ${tenantId}: ${error}`)
+      throw error
+    }
+  }
+}

--- a/backend/src/database.module.ts
+++ b/backend/src/database.module.ts
@@ -23,6 +23,7 @@ import { ApiKeyLimit } from './api/api-keys/entities/api-key-limit.entity'
 import { ApiKeyUsage } from './api/api-keys/entities/api-key-usage.entity'
 import { ApiKeyLimitAlert } from './api/api-keys/entities/api-key-limit-alert.entity'
 import { AttachmentEntity } from './api/attachment/entities/attachment.entity'
+import { TenantSettings } from './api/tenant-settings/entities/tenant-settings.entity'
 
 const dbHost = process.env.POSTGRES_HOST || 'localhost'
 const dbUser = process.env.POSTGRES_USER || 'postgres'
@@ -65,6 +66,7 @@ const dbSchema = process.env.POSTGRES_SCHEMA || 'notify'
         ApiKeyUsage,
         ApiKeyLimitAlert,
         AttachmentEntity,
+        TenantSettings,
       ],
       synchronize: false, // Use Flyway for migrations
       logging: process.env.NODE_ENV !== 'production' ? ['query', 'error'] : ['error'],

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -14,7 +14,6 @@ import { useCstarRoles } from '@/hooks/useCstarRoles'
 import UserService from '@/service/user-service'
 import { SsoRole } from '@/enum/sso-role.enum'
 import Sidebar from './Sidebar'
-import { CstarRole } from '@/enum/cstar-role.enum'
 
 type Props = {
   children: React.ReactNode
@@ -33,8 +32,7 @@ const Layout: FC<Props> = ({ children }) => {
   const rolesError = useAppSelector((state) => state.user.rolesError)
   const cstarRoles = useAppSelector((state) => state.user.current?.cstarRoles)
   const userCurrent = useAppSelector((state) => state.user.current)
-  const { canEdit, hasRole } = useCstarRoles()
-  const isOperationsAdmin = hasRole(CstarRole.NOTIFY_OPERATIONS_ADMIN)
+  const { canEdit } = useCstarRoles()
 
   // Track which tenants we've already fetched roles for in this session
   const rolesFetchedRef = useRef<Set<string>>(new Set())
@@ -88,12 +86,6 @@ const Layout: FC<Props> = ({ children }) => {
       return
     }
 
-    // Settings is restricted to NOTIFY_OPERATIONS_ADMIN.
-    if (location.pathname === '/settings' && !isOperationsAdmin) {
-      navigate({ to: '/not-authorized' })
-      return
-    }
-
     // Feature Flags is open to NOTIFY_OPERATIONS_ADMIN as well as NOTIFY_ADMIN.
     if (
       location.pathname === '/admin/feature-flags' &&
@@ -107,7 +99,6 @@ const Layout: FC<Props> = ({ children }) => {
     rolesError,
     cstarRoles,
     canEdit,
-    isOperationsAdmin,
     location.pathname,
     navigate,
   ])

--- a/frontend/src/components/Sidebar.spec.tsx
+++ b/frontend/src/components/Sidebar.spec.tsx
@@ -6,6 +6,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import authReducer from '@/redux/slices/auth.slice'
 import cstarReducer from '@/redux/slices/cstar.slice'
 import userReducer from '@/redux/slices/user.slice'
+import UserService from '@/service/user-service'
 import Sidebar from './Sidebar'
 
 vi.mock('@tanstack/react-router', () => ({
@@ -67,6 +68,7 @@ function renderSidebar(user: typeof mockUser | null = null, cstarRoles: string[]
 describe('Sidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(UserService.hasRole).mockReturnValue(false)
   })
 
   it('renders primary nav items when user has CSTAR roles', () => {
@@ -83,26 +85,26 @@ describe('Sidebar', () => {
     expect(screen.queryByRole('link', { name: /templates/i })).not.toBeInTheDocument()
   })
 
-  it('hides Settings for NOTIFY_ADMIN users who are not operations admins', async () => {
+  it('shows Tenant Settings for NOTIFY_ADMIN users', async () => {
+    const user = userEvent.setup()
     const UserService = (await import('@/service/user-service')).default
     vi.mocked(UserService.hasRole).mockReturnValue(true)
 
     renderSidebar()
 
-    expect(screen.queryByRole('link', { name: /settings/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /dashboard/i })).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /admin/i }))
+
+    expect(screen.getByRole('link', { name: /tenant settings/i })).toHaveAttribute(
+      'href',
+      '/admin/settings',
+    )
   })
 
-  it('shows the Feature Flags admin link for NOTIFY_OPERATIONS_ADMIN users', async () => {
-    const user = userEvent.setup()
+  it('does not show Admin or Tenant Settings for NOTIFY_OPERATIONS_ADMIN-only users', () => {
     renderSidebar(null, ['NOTIFY_OPERATIONS_ADMIN'])
 
-    const adminButton = screen.getByRole('button', { name: /admin/i })
-    expect(adminButton).toBeInTheDocument()
-
-    await user.click(adminButton)
-
-    expect(screen.getByRole('link', { name: /feature flags/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /admin/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /tenant settings/i })).not.toBeInTheDocument()
   })
 
   it('does not render admin link when user is not an admin', () => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -19,7 +19,6 @@ import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettin
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import ExpandMoreOutlinedIcon from '@mui/icons-material/ExpandMoreOutlined'
-import { CstarRole } from '@/enum/cstar-role.enum'
 
 const navItems = [
   {
@@ -51,6 +50,10 @@ const adminItems = {
       label: 'Usage & Limits',
       to: '/admin/usage',
     },
+    {
+      label: 'Tenant Settings',
+      to: '/admin/settings',
+    },
   ],
 } as const
 
@@ -60,9 +63,8 @@ const Sidebar: FC = () => {
   // Get user from Redux store (populated from JWT token)
   const user = useAppSelector((state) => state.auth.user)
   const cstarTenants = useAppSelector((state) => state.cstar.tenants)
-  const { hasRole, hasTenantRole } = useCstarRoles()
+  const { hasTenantRole } = useCstarRoles()
   const isAdmin = UserService.hasRole(SsoRole.NOTIFY_ADMIN)
-  const isOperationsAdmin = hasRole(CstarRole.NOTIFY_OPERATIONS_ADMIN)
 
   // Determine which menu items to show based on roles
   // Dashboard and Templates require CSTAR roles (assume NOTIFY_VIEWER or similar)
@@ -97,8 +99,7 @@ const Sidebar: FC = () => {
           const shouldShow =
             (item.label === 'Dashboard' && hasTenantRole) ||
             (item.label === 'Templates' && hasTenantRole) ||
-            (item.label === 'Usage & Limits' && showUsage) ||
-            (item.label === 'Settings' && isOperationsAdmin)
+            (item.label === 'Usage & Limits' && showUsage)
 
           return shouldShow ? (
             <Link
@@ -148,6 +149,15 @@ const Sidebar: FC = () => {
                     activeProps={{ className: 'active' }}
                   >
                     <span className="sidebar__label">Usage &amp; Limits</span>
+                  </Link>
+                )}
+                {isAdmin && (
+                  <Link
+                    to="/admin/settings"
+                    className="sidebar__subitem"
+                    activeProps={{ className: 'active' }}
+                  >
+                    <span className="sidebar__label">Tenant Settings</span>
                   </Link>
                 )}
               </div>

--- a/frontend/src/interfaces/tenant-settings.interface.ts
+++ b/frontend/src/interfaces/tenant-settings.interface.ts
@@ -1,0 +1,10 @@
+export interface TenantSettings {
+  id: string
+  tenantId: string
+  alertEmail: string | null
+  createdAt: string
+  createdBy: string | null
+  updatedAt: string
+  updatedBy: string | null
+  isDeleted: boolean
+}

--- a/frontend/src/pages/settings/Settings.spec.tsx
+++ b/frontend/src/pages/settings/Settings.spec.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Settings from './Settings'
+import { showSuccessToast } from '@/redux/utils/toastUtils'
+import { updateTenantSettings } from '@/redux/thunks/tenantSettings.thunks'
+
+const dispatchMock = vi.fn()
+const fetchResults: Record<string, { alertEmail: string | null }> = {}
+
+let state: any
+
+vi.mock('@/redux/hooks', () => ({
+  useAppDispatch: () => dispatchMock,
+  useAppSelector: (selector: (value: unknown) => unknown) => selector(state),
+}))
+
+vi.mock('@/redux/thunks/tenantSettings.thunks', () => ({
+  fetchTenantSettings: vi.fn(() => ({ type: 'tenantSettings/fetch' })),
+  updateTenantSettings: vi.fn((payload) => ({ type: 'tenantSettings/update', payload })),
+}))
+
+vi.mock('@/redux/utils/toastUtils', () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}))
+
+vi.mock('@bcgov/design-system-react-components', () => ({
+  Button: ({ children, isDisabled, ...props }: any) => (
+    <button disabled={isDisabled} {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/PageHeading', () => ({
+  default: ({ title }: { title: string }) => <h1>{title}</h1>,
+}))
+
+function tenant(id: string, name: string) {
+  return { id, name }
+}
+
+describe('Tenant Settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state = {
+      tenant: { selectedTenant: tenant('tenant-1', 'Tenant One') },
+      tenantSettings: { alertEmail: null, loading: false, saving: false },
+    }
+    fetchResults['tenant-1'] = { alertEmail: 'saved@example.com' }
+    fetchResults['tenant-2'] = { alertEmail: 'other@example.com' }
+
+    dispatchMock.mockImplementation((action) => {
+      if (action.type === 'tenantSettings/fetch') {
+        const tenantId = state.tenant.selectedTenant.id
+        return { unwrap: () => Promise.resolve(fetchResults[tenantId]) }
+      }
+
+      return {
+        unwrap: () => Promise.resolve({ alertEmail: action.payload.alertEmail }),
+      }
+    })
+  })
+
+  async function renderLoadedSettings() {
+    const result = render(<Settings />)
+    await screen.findByDisplayValue('saved@example.com')
+    return result
+  }
+
+  it('keeps Save disabled while the loaded value is unchanged', async () => {
+    await renderLoadedSettings()
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('enables Save after a valid edit', async () => {
+    await renderLoadedSettings()
+
+    fireEvent.change(screen.getByLabelText('Alert email'), {
+      target: { value: 'changed@example.com' },
+    })
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+  })
+
+  it('shows an inline error and prevents an invalid email from being saved', async () => {
+    await renderLoadedSettings()
+
+    fireEvent.change(screen.getByLabelText('Alert email'), { target: { value: 'invalid-email' } })
+
+    expect(screen.getByText('Enter a valid alert email address')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    fireEvent.submit(screen.getByRole('button', { name: 'Save' }).closest('form')!)
+    expect(updateTenantSettings).not.toHaveBeenCalled()
+  })
+
+  it('makes the saved value the new clean baseline after a successful save', async () => {
+    await renderLoadedSettings()
+
+    fireEvent.change(screen.getByLabelText('Alert email'), {
+      target: { value: 'changed@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(showSuccessToast).toHaveBeenCalledWith('Tenant settings updated successfully')
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    })
+  })
+
+  it('resets to the newly loaded value when the selected tenant changes', async () => {
+    const { rerender } = await renderLoadedSettings()
+
+    fireEvent.change(screen.getByLabelText('Alert email'), {
+      target: { value: 'unsaved@example.com' },
+    })
+    state = {
+      ...state,
+      tenant: { selectedTenant: tenant('tenant-2', 'Tenant Two') },
+    }
+    rerender(<Settings />)
+
+    expect(await screen.findByDisplayValue('other@example.com')).toBeInTheDocument()
+    expect(screen.queryByDisplayValue('unsaved@example.com')).not.toBeInTheDocument()
+    expect(screen.getByText('Tenant Two')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('disables Save while saving to prevent duplicate submissions', async () => {
+    const { rerender } = await renderLoadedSettings()
+
+    fireEvent.change(screen.getByLabelText('Alert email'), {
+      target: { value: 'changed@example.com' },
+    })
+    state = {
+      ...state,
+      tenantSettings: { ...state.tenantSettings, saving: true },
+    }
+    rerender(<Settings />)
+
+    const saveButton = screen.getByRole('button', { name: 'Saving…' })
+    expect(saveButton).toBeDisabled()
+    fireEvent.click(saveButton)
+    expect(updateTenantSettings).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/settings/Settings.spec.tsx
+++ b/frontend/src/pages/settings/Settings.spec.tsx
@@ -84,21 +84,69 @@ describe('Tenant Settings', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
   })
 
-  it('shows an inline error and prevents an invalid email from being saved', async () => {
+  it('does not show an error during initial invalid typing', async () => {
     await renderLoadedSettings()
 
     fireEvent.change(screen.getByLabelText('Alert email'), { target: { value: 'invalid-email' } })
 
+    expect(screen.queryByText('Enter a valid alert email address')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Alert email')).toHaveAttribute('aria-invalid', 'false')
+  })
+
+  it('shows the inline error after leaving an invalid field', async () => {
+    await renderLoadedSettings()
+
+    const input = screen.getByLabelText('Alert email')
+    fireEvent.change(input, { target: { value: 'invalid-email' } })
+    fireEvent.blur(input)
+
+    expect(screen.getByText('Enter a valid alert email address')).toBeInTheDocument()
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('shows the error on submit without blur and sends no PATCH request', async () => {
+    await renderLoadedSettings()
+
+    fireEvent.change(screen.getByLabelText('Alert email'), { target: { value: 'invalid-email' } })
+    fireEvent.submit(screen.getByRole('button', { name: 'Save' }).closest('form')!)
+
     expect(screen.getByText('Enter a valid alert email address')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
-    fireEvent.submit(screen.getByRole('button', { name: 'Save' }).closest('form')!)
     expect(updateTenantSettings).not.toHaveBeenCalled()
+  })
+
+  it('clears a visible error immediately when the value becomes valid', async () => {
+    await renderLoadedSettings()
+
+    const input = screen.getByLabelText('Alert email')
+    fireEvent.change(input, { target: { value: 'invalid-email' } })
+    fireEvent.blur(input)
+    fireEvent.change(input, { target: { value: 'valid@example.com' } })
+
+    expect(screen.queryByText('Enter a valid alert email address')).not.toBeInTheDocument()
+    expect(input).toHaveAttribute('aria-invalid', 'false')
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+  })
+
+  it('treats blank input as a valid clear operation', async () => {
+    await renderLoadedSettings()
+
+    const input = screen.getByLabelText('Alert email')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    expect(screen.queryByText('Enter a valid alert email address')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
   })
 
   it('makes the saved value the new clean baseline after a successful save', async () => {
     await renderLoadedSettings()
 
-    fireEvent.change(screen.getByLabelText('Alert email'), {
+    const input = screen.getByLabelText('Alert email')
+    fireEvent.change(input, { target: { value: 'invalid-email' } })
+    fireEvent.blur(input)
+    fireEvent.change(input, {
       target: { value: 'changed@example.com' },
     })
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
@@ -107,14 +155,18 @@ describe('Tenant Settings', () => {
       expect(showSuccessToast).toHaveBeenCalledWith('Tenant settings updated successfully')
       expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
     })
+
+    fireEvent.change(input, { target: { value: 'invalid-again' } })
+    expect(screen.queryByText('Enter a valid alert email address')).not.toBeInTheDocument()
   })
 
   it('resets to the newly loaded value when the selected tenant changes', async () => {
     const { rerender } = await renderLoadedSettings()
 
-    fireEvent.change(screen.getByLabelText('Alert email'), {
-      target: { value: 'unsaved@example.com' },
-    })
+    const input = screen.getByLabelText('Alert email')
+    fireEvent.change(input, { target: { value: 'invalid-email' } })
+    fireEvent.blur(input)
+    expect(screen.getByText('Enter a valid alert email address')).toBeInTheDocument()
     state = {
       ...state,
       tenant: { selectedTenant: tenant('tenant-2', 'Tenant Two') },
@@ -123,6 +175,7 @@ describe('Tenant Settings', () => {
 
     expect(await screen.findByDisplayValue('other@example.com')).toBeInTheDocument()
     expect(screen.queryByDisplayValue('unsaved@example.com')).not.toBeInTheDocument()
+    expect(screen.queryByText('Enter a valid alert email address')).not.toBeInTheDocument()
     expect(screen.getByText('Tenant Two')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -6,9 +6,13 @@ import { useAppDispatch, useAppSelector } from '@/redux/hooks'
 import { fetchTenantSettings, updateTenantSettings } from '@/redux/thunks/tenantSettings.thunks'
 import { showErrorToast, showSuccessToast } from '@/redux/utils/toastUtils'
 
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const EMAIL_PATTERN =
+  /^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/i
 
 const normalizeEmail = (value: string): string | null => value.trim() || null
+
+const isValidEmail = (value: string): boolean =>
+  value.length <= 254 && !value.includes('..') && EMAIL_PATTERN.test(value)
 
 const Settings: FC = () => {
   const dispatch = useAppDispatch()
@@ -89,18 +93,23 @@ function SettingsForm({
   onSaved: (value: string | null) => void
 }) {
   const dispatch = useAppDispatch()
+  const [shouldShowValidation, setShouldShowValidation] = useState(false)
   const normalizedEmail = normalizeEmail(emailInput)
-  const emailError =
-    normalizedEmail && !EMAIL_PATTERN.test(normalizedEmail)
-      ? 'Enter a valid alert email address'
-      : ''
+  const validationError =
+    normalizedEmail && !isValidEmail(normalizedEmail) ? 'Enter a valid alert email address' : ''
+  const emailError = shouldShowValidation ? validationError : ''
   const isDirty = normalizedEmail !== savedAlertEmail
   const isSaveDisabled = !isDirty || saving || Boolean(emailError)
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
 
-    if (isSaveDisabled) {
+    if (validationError) {
+      setShouldShowValidation(true)
+      return
+    }
+
+    if (!isDirty || saving) {
       return
     }
 
@@ -109,6 +118,7 @@ function SettingsForm({
         updateTenantSettings({ alertEmail: normalizedEmail }),
       ).unwrap()
       onSaved(updatedSettings.alertEmail)
+      setShouldShowValidation(false)
       showSuccessToast('Tenant settings updated successfully')
     } catch (updateError) {
       showErrorToast(
@@ -130,6 +140,11 @@ function SettingsForm({
           value={emailInput}
           disabled={saving}
           onChange={(event) => onEmailChange(event.target.value)}
+          onBlur={() => {
+            if (validationError) {
+              setShouldShowValidation(true)
+            }
+          }}
           aria-describedby={`alert-email-help${emailError ? ' alert-email-error' : ''}`}
           aria-invalid={Boolean(emailError)}
         />

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -21,7 +21,7 @@ const Settings: FC = () => {
 
   return (
     <div>
-      <PageHeading title="Settings" />
+      <PageHeading title="Tenant Settings" />
 
       {error && <div className="alert alert-danger mb-3">{error}</div>}
 

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -8,14 +8,44 @@ import { showErrorToast, showSuccessToast } from '@/redux/utils/toastUtils'
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
+const normalizeEmail = (value: string): string | null => value.trim() || null
+
 const Settings: FC = () => {
   const dispatch = useAppDispatch()
   const selectedTenant = useAppSelector((state) => state.tenant.selectedTenant)
-  const { alertEmail, loading, saving, error } = useAppSelector((state) => state.tenantSettings)
+  const { loading, saving, error } = useAppSelector((state) => state.tenantSettings)
+  const [savedAlertEmail, setSavedAlertEmail] = useState<string | null>(null)
+  const [emailInput, setEmailInput] = useState('')
+  const [loadedTenantId, setLoadedTenantId] = useState<string | null>(null)
 
   useEffect(() => {
-    if (selectedTenant) {
-      dispatch(fetchTenantSettings())
+    let active = true
+
+    if (!selectedTenant) {
+      return () => {
+        active = false
+      }
+    }
+
+    dispatch(fetchTenantSettings())
+      .unwrap()
+      .then((settings) => {
+        if (!active) return
+
+        const nextAlertEmail = settings?.alertEmail ?? null
+        setSavedAlertEmail(nextAlertEmail)
+        setEmailInput(nextAlertEmail ?? '')
+        setLoadedTenantId(selectedTenant.id)
+      })
+      .catch(() => {
+        if (active) {
+          // The slice exposes the load error below; keep a clean empty form available.
+          setLoadedTenantId(selectedTenant.id)
+        }
+      })
+
+    return () => {
+      active = false
     }
   }, [selectedTenant, dispatch])
 
@@ -23,15 +53,22 @@ const Settings: FC = () => {
     <div>
       <PageHeading title="Tenant Settings" />
 
+      {selectedTenant && <p className="text-muted mb-3">{selectedTenant.name}</p>}
+
       {error && <div className="alert alert-danger mb-3">{error}</div>}
 
-      {loading ? (
+      {loading || loadedTenantId !== selectedTenant?.id ? (
         <p className="text-muted">Loading tenant settings...</p>
       ) : (
         <SettingsForm
-          key={`${selectedTenant?.id ?? ''}:${alertEmail ?? ''}`}
-          initialAlertEmail={alertEmail}
+          emailInput={emailInput}
+          savedAlertEmail={savedAlertEmail}
           saving={saving}
+          onEmailChange={setEmailInput}
+          onSaved={(alertEmail) => {
+            setSavedAlertEmail(alertEmail)
+            setEmailInput(alertEmail ?? '')
+          }}
         />
       )}
     </div>
@@ -39,26 +76,39 @@ const Settings: FC = () => {
 }
 
 function SettingsForm({
-  initialAlertEmail,
+  emailInput,
+  savedAlertEmail,
   saving,
+  onEmailChange,
+  onSaved,
 }: {
-  initialAlertEmail: string | null
+  emailInput: string
+  savedAlertEmail: string | null
   saving: boolean
+  onEmailChange: (value: string) => void
+  onSaved: (value: string | null) => void
 }) {
   const dispatch = useAppDispatch()
-  const [emailInput, setEmailInput] = useState(initialAlertEmail ?? '')
+  const normalizedEmail = normalizeEmail(emailInput)
+  const emailError =
+    normalizedEmail && !EMAIL_PATTERN.test(normalizedEmail)
+      ? 'Enter a valid alert email address'
+      : ''
+  const isDirty = normalizedEmail !== savedAlertEmail
+  const isSaveDisabled = !isDirty || saving || Boolean(emailError)
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
 
-    const trimmedEmail = emailInput.trim()
-    if (trimmedEmail && !EMAIL_PATTERN.test(trimmedEmail)) {
-      showErrorToast('Enter a valid alert email address')
+    if (isSaveDisabled) {
       return
     }
 
     try {
-      await dispatch(updateTenantSettings({ alertEmail: trimmedEmail || null })).unwrap()
+      const updatedSettings = await dispatch(
+        updateTenantSettings({ alertEmail: normalizedEmail }),
+      ).unwrap()
+      onSaved(updatedSettings.alertEmail)
       showSuccessToast('Tenant settings updated successfully')
     } catch (updateError) {
       showErrorToast(
@@ -76,19 +126,25 @@ function SettingsForm({
         <input
           id="alert-email"
           type="email"
-          className="form-control"
+          className={`form-control${emailError ? ' is-invalid' : ''}`}
           value={emailInput}
           disabled={saving}
-          onChange={(event) => setEmailInput(event.target.value)}
-          aria-describedby="alert-email-help"
+          onChange={(event) => onEmailChange(event.target.value)}
+          aria-describedby={`alert-email-help${emailError ? ' alert-email-error' : ''}`}
+          aria-invalid={Boolean(emailError)}
         />
+        {emailError && (
+          <span id="alert-email-error" className="bcds-react-aria-TextField--Error">
+            {emailError}
+          </span>
+        )}
         <div id="alert-email-help" className="form-text">
           System and limit alerts for this tenant will be sent to this address. Leave blank to clear
           it.
         </div>
       </div>
 
-      <Button type="submit" variant="primary" isDisabled={saving}>
+      <Button type="submit" variant="primary" isDisabled={isSaveDisabled}>
         {saving ? 'Saving…' : 'Save'}
       </Button>
     </form>

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import type { FC, FormEvent } from 'react'
+import { Button } from '@bcgov/design-system-react-components'
+import PageHeading from '@/components/PageHeading'
+import { useAppDispatch, useAppSelector } from '@/redux/hooks'
+import { fetchTenantSettings, updateTenantSettings } from '@/redux/thunks/tenantSettings.thunks'
+import { showErrorToast, showSuccessToast } from '@/redux/utils/toastUtils'
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const Settings: FC = () => {
+  const dispatch = useAppDispatch()
+  const selectedTenant = useAppSelector((state) => state.tenant.selectedTenant)
+  const { alertEmail, loading, saving, error } = useAppSelector((state) => state.tenantSettings)
+
+  useEffect(() => {
+    if (selectedTenant) {
+      dispatch(fetchTenantSettings())
+    }
+  }, [selectedTenant, dispatch])
+
+  return (
+    <div>
+      <PageHeading title="Settings" />
+
+      {error && <div className="alert alert-danger mb-3">{error}</div>}
+
+      {loading ? (
+        <p className="text-muted">Loading tenant settings...</p>
+      ) : (
+        <SettingsForm
+          key={`${selectedTenant?.id ?? ''}:${alertEmail ?? ''}`}
+          initialAlertEmail={alertEmail}
+          saving={saving}
+        />
+      )}
+    </div>
+  )
+}
+
+function SettingsForm({
+  initialAlertEmail,
+  saving,
+}: {
+  initialAlertEmail: string | null
+  saving: boolean
+}) {
+  const dispatch = useAppDispatch()
+  const [emailInput, setEmailInput] = useState(initialAlertEmail ?? '')
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const trimmedEmail = emailInput.trim()
+    if (trimmedEmail && !EMAIL_PATTERN.test(trimmedEmail)) {
+      showErrorToast('Enter a valid alert email address')
+      return
+    }
+
+    try {
+      await dispatch(updateTenantSettings({ alertEmail: trimmedEmail || null })).unwrap()
+      showSuccessToast('Tenant settings updated successfully')
+    } catch (updateError) {
+      showErrorToast(
+        typeof updateError === 'string' ? updateError : 'Failed to update tenant settings',
+      )
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="mb-3">
+        <label htmlFor="alert-email" className="form-label">
+          Alert email
+        </label>
+        <input
+          id="alert-email"
+          type="email"
+          className="form-control"
+          value={emailInput}
+          disabled={saving}
+          onChange={(event) => setEmailInput(event.target.value)}
+          aria-describedby="alert-email-help"
+        />
+        <div id="alert-email-help" className="form-text">
+          System and limit alerts for this tenant will be sent to this address. Leave blank to clear
+          it.
+        </div>
+      </div>
+
+      <Button type="submit" variant="primary" isDisabled={saving}>
+        {saving ? 'Saving…' : 'Save'}
+      </Button>
+    </form>
+  )
+}
+
+export default Settings

--- a/frontend/src/redux/slices/tenantSettings.slice.spec.ts
+++ b/frontend/src/redux/slices/tenantSettings.slice.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import tenantSettingsReducer from './tenantSettings.slice'
+import { fetchTenantSettings, updateTenantSettings } from '../thunks/tenantSettings.thunks'
+import type { TenantSettings } from '@/interfaces/tenant-settings.interface'
+
+describe('tenantSettingsSlice', () => {
+  const initialState = {
+    alertEmail: null,
+    loading: false,
+    saving: false,
+  }
+
+  const tenantSettings: TenantSettings = {
+    id: 'settings-1',
+    tenantId: 'tenant-1',
+    alertEmail: 'alerts@example.com',
+    createdAt: '2026-07-21T00:00:00.000Z',
+    createdBy: 'user-1',
+    updatedAt: '2026-07-21T00:00:00.000Z',
+    updatedBy: 'user-1',
+    isDeleted: false,
+  }
+
+  it('should have initial state', () => {
+    const state = tenantSettingsReducer(undefined, { type: 'unknown' })
+
+    expect(state).toEqual(initialState)
+  })
+
+  describe('fetchTenantSettings thunk', () => {
+    it('should handle pending state', () => {
+      const state = tenantSettingsReducer(
+        initialState,
+        fetchTenantSettings.pending('', undefined, {}),
+      )
+
+      expect(state.loading).toBe(true)
+      expect(state.error).toBeUndefined()
+    })
+
+    it('should handle fulfilled state', () => {
+      const state = tenantSettingsReducer(
+        { ...initialState, loading: true },
+        fetchTenantSettings.fulfilled(tenantSettings, '', undefined),
+      )
+
+      expect(state.alertEmail).toBe('alerts@example.com')
+      expect(state.loading).toBe(false)
+    })
+
+    it('should handle rejected state', () => {
+      const error = 'Failed to load tenant settings'
+      const state = tenantSettingsReducer(
+        { ...initialState, loading: true },
+        fetchTenantSettings.rejected(new Error(), '', undefined, error),
+      )
+
+      expect(state.loading).toBe(false)
+      expect(state.error).toBe(error)
+    })
+  })
+
+  describe('updateTenantSettings thunk', () => {
+    it('should handle pending state', () => {
+      const state = tenantSettingsReducer(
+        initialState,
+        updateTenantSettings.pending('', { alertEmail: 'alerts@example.com' }, {}),
+      )
+
+      expect(state.saving).toBe(true)
+      expect(state.loading).toBe(false)
+      expect(state.error).toBeUndefined()
+    })
+
+    it('should handle fulfilled state', () => {
+      const payload = { ...tenantSettings, alertEmail: 'updated@example.com' }
+      const state = tenantSettingsReducer(
+        { ...initialState, saving: true },
+        updateTenantSettings.fulfilled(payload, '', { alertEmail: 'updated@example.com' }),
+      )
+
+      expect(state.alertEmail).toBe('updated@example.com')
+      expect(state.saving).toBe(false)
+    })
+
+    it('should handle rejected state', () => {
+      const error = 'Failed to update tenant settings'
+      const state = tenantSettingsReducer(
+        { ...initialState, saving: true },
+        updateTenantSettings.rejected(new Error(), '', { alertEmail: 'alerts@example.com' }, error),
+      )
+
+      expect(state.saving).toBe(false)
+      expect(state.error).toBe(error)
+    })
+  })
+})

--- a/frontend/src/redux/slices/tenantSettings.slice.ts
+++ b/frontend/src/redux/slices/tenantSettings.slice.ts
@@ -1,0 +1,50 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { fetchTenantSettings, updateTenantSettings } from '../thunks/tenantSettings.thunks'
+
+interface TenantSettingsState {
+  alertEmail: string | null
+  loading: boolean
+  saving: boolean
+  error?: string
+}
+
+const initialState: TenantSettingsState = {
+  alertEmail: null,
+  loading: false,
+  saving: false,
+}
+
+export const tenantSettingsSlice = createSlice({
+  name: 'tenantSettings',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchTenantSettings.pending, (state) => {
+        state.loading = true
+        state.error = undefined
+      })
+      .addCase(fetchTenantSettings.fulfilled, (state, action) => {
+        state.alertEmail = action.payload?.alertEmail ?? null
+        state.loading = false
+      })
+      .addCase(fetchTenantSettings.rejected, (state, action) => {
+        state.loading = false
+        state.error = action.payload ?? 'Failed to load tenant settings'
+      })
+      .addCase(updateTenantSettings.pending, (state) => {
+        state.saving = true
+        state.error = undefined
+      })
+      .addCase(updateTenantSettings.fulfilled, (state, action) => {
+        state.alertEmail = action.payload.alertEmail
+        state.saving = false
+      })
+      .addCase(updateTenantSettings.rejected, (state, action) => {
+        state.saving = false
+        state.error = action.payload ?? 'Failed to update tenant settings'
+      })
+  },
+})
+
+export default tenantSettingsSlice.reducer

--- a/frontend/src/redux/store.ts
+++ b/frontend/src/redux/store.ts
@@ -13,6 +13,7 @@ import featureFlagsReducer from './slices/featureFlags.slice'
 import adminTenantsReducer from './slices/adminTenants.slice'
 import apiKeysReducer from './slices/apiKeys.slice'
 import apiKeyUsageReducer from './slices/apiKeyUsage.slice'
+import tenantSettingsReducer from './slices/tenantSettings.slice'
 
 export const store = configureStore({
   reducer: {
@@ -30,6 +31,7 @@ export const store = configureStore({
     adminTenants: adminTenantsReducer,
     apiKeys: apiKeysReducer,
     apiKeyUsage: apiKeyUsageReducer,
+    tenantSettings: tenantSettingsReducer,
   },
 })
 

--- a/frontend/src/redux/thunks/tenantSettings.thunks.ts
+++ b/frontend/src/redux/thunks/tenantSettings.thunks.ts
@@ -1,0 +1,40 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { get, patch } from '@/common/api'
+import type { TenantSettings } from '@/interfaces/tenant-settings.interface'
+import type { RootState } from '../store'
+
+export const fetchTenantSettings = createAsyncThunk<
+  TenantSettings | null,
+  void,
+  { state: RootState; rejectValue: string }
+>('tenantSettings/fetch', async (_, { getState, rejectWithValue }) => {
+  try {
+    const tenantId = getState().tenant.selectedTenant?.id
+    if (!tenantId) return null
+
+    return await get<TenantSettings | null>({
+      url: '/api/v1/frontend/tenant-settings',
+    })
+  } catch (error) {
+    return rejectWithValue(
+      error instanceof Error ? error.message : 'Failed to load tenant settings',
+    )
+  }
+})
+
+export const updateTenantSettings = createAsyncThunk<
+  TenantSettings,
+  { alertEmail: string | null },
+  { rejectValue: string }
+>('tenantSettings/update', async (payload, { rejectWithValue }) => {
+  try {
+    return await patch<TenantSettings, { alertEmail: string | null }>({
+      url: '/api/v1/frontend/tenant-settings',
+      params: payload,
+    })
+  } catch (error) {
+    return rejectWithValue(
+      error instanceof Error ? error.message : 'Failed to update tenant settings',
+    )
+  }
+})

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TemplateEditTemplateIdRouteImport } from './routes/template-edit/$templateId'
 import { Route as AdminUsageRouteImport } from './routes/admin/usage'
+import { Route as AdminSettingsRouteImport } from './routes/admin/settings'
 import { Route as AdminFeatureFlagsRouteImport } from './routes/admin/feature-flags'
 
 const UsageRoute = UsageRouteImport.update({
@@ -59,6 +60,11 @@ const AdminUsageRoute = AdminUsageRouteImport.update({
   path: '/admin/usage',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminSettingsRoute = AdminSettingsRouteImport.update({
+  id: '/admin/settings',
+  path: '/admin/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AdminFeatureFlagsRoute = AdminFeatureFlagsRouteImport.update({
   id: '/admin/feature-flags',
   path: '/admin/feature-flags',
@@ -73,6 +79,7 @@ export interface FileRoutesByFullPath {
   '/templates': typeof TemplatesRoute
   '/usage': typeof UsageRoute
   '/admin/feature-flags': typeof AdminFeatureFlagsRoute
+  '/admin/settings': typeof AdminSettingsRoute
   '/admin/usage': typeof AdminUsageRoute
   '/template-edit/$templateId': typeof TemplateEditTemplateIdRoute
 }
@@ -84,6 +91,7 @@ export interface FileRoutesByTo {
   '/templates': typeof TemplatesRoute
   '/usage': typeof UsageRoute
   '/admin/feature-flags': typeof AdminFeatureFlagsRoute
+  '/admin/settings': typeof AdminSettingsRoute
   '/admin/usage': typeof AdminUsageRoute
   '/template-edit/$templateId': typeof TemplateEditTemplateIdRoute
 }
@@ -96,6 +104,7 @@ export interface FileRoutesById {
   '/templates': typeof TemplatesRoute
   '/usage': typeof UsageRoute
   '/admin/feature-flags': typeof AdminFeatureFlagsRoute
+  '/admin/settings': typeof AdminSettingsRoute
   '/admin/usage': typeof AdminUsageRoute
   '/template-edit/$templateId': typeof TemplateEditTemplateIdRoute
 }
@@ -109,6 +118,7 @@ export interface FileRouteTypes {
     | '/templates'
     | '/usage'
     | '/admin/feature-flags'
+    | '/admin/settings'
     | '/admin/usage'
     | '/template-edit/$templateId'
   fileRoutesByTo: FileRoutesByTo
@@ -120,6 +130,7 @@ export interface FileRouteTypes {
     | '/templates'
     | '/usage'
     | '/admin/feature-flags'
+    | '/admin/settings'
     | '/admin/usage'
     | '/template-edit/$templateId'
   id:
@@ -131,6 +142,7 @@ export interface FileRouteTypes {
     | '/templates'
     | '/usage'
     | '/admin/feature-flags'
+    | '/admin/settings'
     | '/admin/usage'
     | '/template-edit/$templateId'
   fileRoutesById: FileRoutesById
@@ -143,6 +155,7 @@ export interface RootRouteChildren {
   TemplatesRoute: typeof TemplatesRoute
   UsageRoute: typeof UsageRoute
   AdminFeatureFlagsRoute: typeof AdminFeatureFlagsRoute
+  AdminSettingsRoute: typeof AdminSettingsRoute
   AdminUsageRoute: typeof AdminUsageRoute
   TemplateEditTemplateIdRoute: typeof TemplateEditTemplateIdRoute
 }
@@ -205,6 +218,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminUsageRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/settings': {
+      id: '/admin/settings'
+      path: '/admin/settings'
+      fullPath: '/admin/settings'
+      preLoaderRoute: typeof AdminSettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/admin/feature-flags': {
       id: '/admin/feature-flags'
       path: '/admin/feature-flags'
@@ -223,6 +243,7 @@ const rootRouteChildren: RootRouteChildren = {
   TemplatesRoute: TemplatesRoute,
   UsageRoute: UsageRoute,
   AdminFeatureFlagsRoute: AdminFeatureFlagsRoute,
+  AdminSettingsRoute: AdminSettingsRoute,
   AdminUsageRoute: AdminUsageRoute,
   TemplateEditTemplateIdRoute: TemplateEditTemplateIdRoute,
 }

--- a/frontend/src/routes/admin/-settings.spec.ts
+++ b/frontend/src/routes/admin/-settings.spec.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import UserService from '@/service/user-service'
+import { Route } from './settings'
+
+vi.mock('@/service/user-service', () => ({
+  default: {
+    hasRole: vi.fn(),
+  },
+}))
+
+describe('/admin/settings authorization', () => {
+  beforeEach(() => {
+    vi.mocked(UserService.hasRole).mockReset()
+  })
+
+  it('allows a global admin', () => {
+    vi.mocked(UserService.hasRole).mockReturnValue(true)
+
+    expect(() => Route.options.beforeLoad?.({} as never)).not.toThrow()
+  })
+
+  it('redirects a non-global-admin user', () => {
+    vi.mocked(UserService.hasRole).mockReturnValue(false)
+
+    expect(() => Route.options.beforeLoad?.({} as never)).toThrow()
+  })
+})

--- a/frontend/src/routes/admin/settings.tsx
+++ b/frontend/src/routes/admin/settings.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import Settings from '@/pages/settings/Settings'
+import UserService from '@/service/user-service'
+import { SsoRole } from '@/enum/sso-role.enum'
+
+export const Route = createFileRoute('/admin/settings')({
+  beforeLoad: () => {
+    if (!UserService.hasRole(SsoRole.NOTIFY_ADMIN)) {
+      throw redirect({ to: '/not-authorized' })
+    }
+  },
+  component: SettingsPage,
+})
+
+function SettingsPage() {
+  return <Settings />
+}

--- a/migrations/sql/V42__create_tenant_settings.sql
+++ b/migrations/sql/V42__create_tenant_settings.sql
@@ -1,0 +1,36 @@
+-- V41: Per-tenant settings.
+--
+-- Holds tenant-scoped configuration, one row per tenant. Starts with a single
+-- setting (the alert email address) and is intended to grow: future scalar
+-- settings (header/logo image URL, from-name, footer text, etc.) are added here
+-- as additional columns as those features land.
+CREATE TABLE IF NOT EXISTS
+  notify.tenant_settings (
+    id UUID NOT NULL DEFAULT gen_random_uuid (),
+    tenant_id UUID NOT NULL,
+    alert_email VARCHAR(320),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now (),
+    created_by VARCHAR(200),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now (),
+    updated_by VARCHAR(200),
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT pk_tenant_settings PRIMARY KEY (id),
+    CONSTRAINT uq_tenant_settings_tenant UNIQUE (tenant_id),
+    CONSTRAINT fk_tenant_settings_tenant FOREIGN KEY (tenant_id) REFERENCES notify.tenant (id) ON DELETE CASCADE
+  );
+
+CREATE TRIGGER trg_tenant_settings_updated_at
+    BEFORE UPDATE ON notify.tenant_settings
+    FOR EACH ROW EXECUTE FUNCTION notify.set_updated_at();
+
+CREATE INDEX idx_tenant_settings_tenant ON notify.tenant_settings (tenant_id) WHERE is_deleted = FALSE;
+
+COMMENT ON TABLE notify.tenant_settings IS 'Tenant-scoped configuration settings, one row per tenant. Column-per-setting; grows over time (alert email, header image, from-name, etc.).';
+COMMENT ON COLUMN notify.tenant_settings.id IS 'Unique identifier for the tenant settings row.';
+COMMENT ON COLUMN notify.tenant_settings.tenant_id IS 'The tenant these settings belong to. Unique: at most one settings row per tenant.';
+COMMENT ON COLUMN notify.tenant_settings.alert_email IS 'Email address that system and limit alerts for this tenant are sent to. Nullable when no alert recipient is configured.';
+COMMENT ON COLUMN notify.tenant_settings.created_at IS 'Timestamp with timezone when the settings record was created.';
+COMMENT ON COLUMN notify.tenant_settings.created_by IS 'Identifier of the user or process that created this record.';
+COMMENT ON COLUMN notify.tenant_settings.updated_at IS 'Timestamp with timezone when the settings record was last updated. Automatically maintained by trg_tenant_settings_updated_at trigger.';
+COMMENT ON COLUMN notify.tenant_settings.updated_by IS 'Identifier of the user or process that last updated this record.';
+COMMENT ON COLUMN notify.tenant_settings.is_deleted IS 'Soft delete flag. When true, the settings row is considered inactive and excluded from normal queries.';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Implements the first phase of per-tenant configuration by adding a Tenant Settings page for managing the tenant alert email address. This establishes the foundation for future tenant-scoped settings while delivering the initial alert email configuration described in the ticket.
Backend
Added a tenant settings API to retrieve and update tenant-scoped configuration.
Added persistence for the new tenant_settings table.
Supports creating or updating a single settings record per tenant.
Restricted access to NOTIFY_ADMIN users.

API Gateway
Added frontend routes for the Tenant Settings API with existing JWT authentication.

Frontend
Added a new Admin → Tenant Settings page.
Allows administrators to view and update the tenant alert email address.
Moved the page under the existing Admin section alongside Feature Flags and Usage & Limits.
Displays the currently selected tenant.

Validation & UX
Email validation is aligned with backend validation rules.
Validation is shown after blur or form submission rather than while the user is initially typing.
Prevents invalid submissions from reaching the API.
Save is enabled only when there are valid unsaved changes.

This introduces the initial implementation of the new tenant_settings table described in the ticket. The schema is intentionally designed to grow over time with additional tenant-scoped configuration (for example header/logo images, from-name, footer text, and other future settings).

Fixes # CCP-4958

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] New unit tests



## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-165.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-165.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)