### PR TITLE
fix: preserve DEV gateway service when PR workflows run

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,15 +64,49 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate PR config from PR branch
+      - name: Generate DEV + all PR configs (preserve DEV)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Generate PR config only from PR branch code
-          # PR shares tag ns.gw-fe8c5.dev with DEV (path-based routing)
-          # DEV service already exists from merge workflow - only apply PR service
           chmod +x api-gateway/scripts/generate-gateway-config.sh
-          api-gateway/scripts/generate-gateway-config.sh pr common-notify-${{ github.event.number }}
+          chmod +x api-gateway/scripts/generate-gateway-for-stage.sh
 
-      - name: Apply PR config (path-based routing)
+          # Generate DEV config first (main routes)
+          api-gateway/scripts/generate-gateway-for-stage.sh dev
+
+          # Start with DEV as base
+          cp api-gateway/generated/gw-active-services.yaml api-gateway/generated/gw-dev-with-prs.yaml
+
+          # Find all open PRs (including this one)
+          OPEN_PRS=$(gh pr list --state open --json number --jq '.[].number')
+
+          if [ -z "$OPEN_PRS" ]; then
+            echo "No other open PRs found - applying DEV + this PR only"
+            # Just this PR
+            api-gateway/scripts/generate-gateway-config.sh pr common-notify-${{ github.event.number }}
+            echo "---" >> api-gateway/generated/gw-dev-with-prs.yaml
+            cat api-gateway/generated/gw-routes-pr.yaml >> api-gateway/generated/gw-dev-with-prs.yaml
+          else
+            echo "Found open PRs: $OPEN_PRS"
+            echo "Generating PR configs to preserve all routes alongside DEV..."
+
+            # Generate and append each open PR config (including this one if already open)
+            for PR_NUM in $OPEN_PRS; do
+              echo "Adding PR-${PR_NUM} routes..."
+              api-gateway/scripts/generate-gateway-config.sh pr common-notify-${PR_NUM}
+
+              # Append PR config to combined file
+              echo "---" >> api-gateway/generated/gw-dev-with-prs.yaml
+              cat api-gateway/generated/gw-routes-pr.yaml >> api-gateway/generated/gw-dev-with-prs.yaml
+            done
+
+            echo "✅ Combined DEV + ${OPEN_PRS} PR route(s)"
+          fi
+
+          # Use combined file for apply
+          mv api-gateway/generated/gw-dev-with-prs.yaml api-gateway/generated/gw-active-services.yaml
+
+      - name: Apply combined DEV + PR config (preserves DEV)
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
@@ -88,30 +122,24 @@ jobs:
           # Set gateway context
           gwa config set gateway gw-fe8c5
 
-          # Apply PR config only
-          # PR shares tag ns.gw-fe8c5.dev with DEV for path-based routing
-          # DEV service already exists from merge workflow
-          # This adds PR routes without affecting DEV routes (different paths)
-          echo "✅ Applying PR config (path-based routing /pr-${{ github.event.number }}/)"
+          # Apply combined DEV + all PRs config
+          # This preserves DEV routes while adding/updating PR routes
+          echo "✅ Applying combined DEV + PR config (path-based routing /pr-${{ github.event.number }}/)"
 
-          gwa apply -i api-gateway/generated/gw-routes-pr.yaml 2>&1 | tee /tmp/gwa-output.txt
+          set +e
+          OUT=$(gwa apply -i api-gateway/generated/gw-active-services.yaml 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUT"
 
-          # Check results
-          if grep -q "Published" /tmp/gwa-output.txt; then
-            PUBLISHED_COUNT=$(grep -oP '\d+(?=/\d+ Published)' /tmp/gwa-output.txt || echo "0")
-            echo "✅ Published $PUBLISHED_COUNT gateway service(s)"
-
-            if [ "$PUBLISHED_COUNT" -gt 0 ]; then
-              echo "✅ PR gateway config published successfully"
-              echo "   Routes available at: https://gw-fe8c5-notify.dev.api.gov.bc.ca/pr-${{ github.event.number }}/"
-              exit 0
-            fi
+          # gwa can exit 0 even when the publish is rejected — fail on non-zero exit or rejection markers
+          if [ "$STATUS" -ne 0 ] || echo "$OUT" | grep -qiE "publish failed|Errors encountered|Rejecting request|Validation Errors"; then
+            echo "::error::gwa apply failed for PR gateway config"
+            exit 1
           fi
 
-          # If we got here, nothing was published
-          echo "❌ Gateway config failed to publish"
-          cat /tmp/gwa-output.txt
-          exit 1
+          echo "✅ PR gateway config published successfully"
+          echo "   Routes available at: https://gw-fe8c5-notify.dev.api.gov.bc.ca/pr-${{ github.event.number }}/"
 
   deploys:
     name: Deploys (${{ github.event.number }})

--- a/frontend/src/redux/slices/featureFlags.slice.ts
+++ b/frontend/src/redux/slices/featureFlags.slice.ts
@@ -114,7 +114,6 @@ const featureFlagsSlice = createSlice({
       .addCase(fetchAllFeatureFlags.rejected, (state, action) => {
         state.loading = false
         state.error = action.payload as string
-        state.flagsList = [] // Ensure flagsList is always an array to prevent spread errors
       })
 
     // Create feature flag

--- a/frontend/src/redux/slices/featureFlags.slice.ts
+++ b/frontend/src/redux/slices/featureFlags.slice.ts
@@ -114,6 +114,7 @@ const featureFlagsSlice = createSlice({
       .addCase(fetchAllFeatureFlags.rejected, (state, action) => {
         state.loading = false
         state.error = action.payload as string
+        state.flagsList = [] // Ensure flagsList is always an array to prevent spread errors
       })
 
     // Create feature flag


### PR DESCRIPTION
## Problem

When any PR workflow runs, the DEV gateway service (`gw-fe8c5-notify-dev`) gets **deleted** from the API Gateway.

**Root Cause:**
- DEV and PR services both share the same tag: `ns.gw-fe8c5.dev`
- PR workflow was applying ONLY the single PR's config
- Kong reconciles and sees: "file with tag `ns.gw-fe8c5.dev` doesn't contain `gw-fe8c5-notify-dev`"
- Kong deletes DEV service to match the file
- DEV disappears from dashboard, routes stop working

## Solution

Updated PR workflow to match the merge workflow pattern:
1. Generate DEV config first
2. Find all open PRs (using `gh pr list`)
3. Generate each PR's config
4. Combine DEV + all PRs into single file
5. Apply combined file

Now Kong sees all services (DEV + all PRs) in one file → preserves all of them.

## Changes

**File:** `.github/workflows/pr-open.yml`
- Step renamed: "Generate DEV + all PR configs (preserve DEV)"
- Added: DEV config generation
- Added: Loop through all open PRs
- Changed: Apply combined file instead of PR-only file

## Testing

This PR will test itself:
- ✅ Workflow should combine DEV + this PR + all other open PRs
- ✅ DEV gateway should remain visible in dashboard after workflow runs
- ✅ This PR's routes should work at `/pr-XXX/` paths
- ✅ No deletions of DEV or other PR services

## Related

- Fixes CCP-5340
- Aligns PR workflow with merge workflow behavior (lines 87-118 in `merge.yml`)

## Before/After

**Before (BROKEN):**
```bash
# Only generated this PR
generate-gateway-config.sh pr common-notify-$PR_NUMBER
gwa apply -i gw-routes-pr.yaml  # ❌ Deletes DEV!
```

**After (FIXED):**
```bash
# Generate DEV + all PRs
generate-gateway-for-stage.sh dev
for each PR: append to combined file
gwa apply -i gw-active-services.yaml  # ✅ Preserves DEV!
```

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-172.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-172.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)