### PR TITLE
fix: api gateway fix

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Generate DEV gateway configuration
         run: |
           chmod +x api-gateway/scripts/generate-gateway-for-stage.sh
-          # Generate DEV routes (tag ns.gw-fe8c5.dev). Published below as a partial set
-          # scoped to the dev qualifier, so TEST/PROD routes are left untouched.
+          # Generate DEV's routes standalone (tagged ns.gw-fe8c5.dev). TEST/PROD are published
+          # independently under their own qualifiers in the jobs below and are not affected.
           api-gateway/scripts/generate-gateway-for-stage.sh dev
 
       - name: Add open PR routes (path-based routing)
@@ -117,6 +117,11 @@ jobs:
           mv api-gateway/generated/gw-dev-with-prs.yaml api-gateway/generated/gw-active-services.yaml
           echo "✅ Combined DEV + ${OPEN_PRS} PR route(s)"
 
+      # NOTE: DEV intentionally still uses `gwa apply` (unlike TEST/PROD below).
+      # The DEV config bundles the open-PR routes, which are path-based (/pr-N/...) and rely on
+      # gwa-api's own path handling. The raw-Kong conversion used for TEST/PROD cannot reproduce
+      # that prefix-stripping, so converting DEV would break every open PR environment.
+      # DEV's routes are already current, so there is nothing to gain by changing this.
       - name: Publish DEV gateway config (with open PRs)
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
@@ -185,24 +190,27 @@ jobs:
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
+          # Convert kind:GatewayService -> raw Kong config (nested plugins, strip_path:false)
+          python3 -c 'import yaml' >/dev/null 2>&1 || pip3 install --quiet --break-system-packages pyyaml
+          python3 api-gateway/scripts/gwservice-to-kong.py \
+            api-gateway/generated/gw-routes-test.yaml > api-gateway/generated/gw-kong-test.yaml
           curl -L https://github.com/bcgov/gwa-cli/releases/download/v3.0.7/gwa_Linux_x86_64.tgz | tar -xz
           sudo mv gwa /usr/local/bin/
           CLIENT_ID=$(echo "$GWA_ACCT" | jq -r '.client_id')
           CLIENT_SECRET=$(echo "$GWA_ACCT" | jq -r '.client_secret')
           gwa login --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET"
           gwa config set gateway gw-fe8c5
-          # Apply ONLY the test GatewayService (single qualifier tag ns.gw-fe8c5.test). Applying a
-          # single-qualifier file avoids the "Too many different qualified gateways" rejection, and
-          # the tag scopes the reconcile so DEV/PROD routes are left untouched.
-          echo "Applying TEST gateway config…"
+          # Publish the test qualifier as a partial set. --qualifier scopes the reconcile so
+          # DEV/PROD (other qualifiers) are left untouched.
+          echo "Publishing TEST gateway config (qualifier=test)…"
           set +e
-          OUT=$(gwa apply -i api-gateway/generated/gw-routes-test.yaml 2>&1)
+          OUT=$(gwa publish-gateway api-gateway/generated/gw-kong-test.yaml --qualifier test 2>&1)
           STATUS=$?
           set -e
           echo "$OUT"
           # gwa can exit 0 even when the publish is rejected — fail on non-zero exit or rejection markers.
-          if [ "$STATUS" -ne 0 ] || echo "$OUT" | grep -qiE "publish failed|Errors encountered|Rejecting request|Validation Errors"; then
-            echo "::error::gwa apply failed for the test gateway config"
+          if [ "$STATUS" -ne 0 ] || echo "$OUT" | grep -qiE "publish failed|Errors encountered|Rejecting request|Validation Errors|Sync Failed"; then
+            echo "::error::gwa publish-gateway failed for qualifier=test"
             exit 1
           fi
 
@@ -257,23 +265,27 @@ jobs:
         env:
           GWA_ACCT: ${{ secrets.GWA_ACCT }}
         run: |
+          # Convert kind:GatewayService -> raw Kong config (nested plugins, strip_path:false)
+          python3 -c 'import yaml' >/dev/null 2>&1 || pip3 install --quiet --break-system-packages pyyaml
+          python3 api-gateway/scripts/gwservice-to-kong.py \
+            api-gateway/generated/gw-routes-prod.yaml > api-gateway/generated/gw-kong-prod.yaml
           curl -L https://github.com/bcgov/gwa-cli/releases/download/v3.0.7/gwa_Linux_x86_64.tgz | tar -xz
           sudo mv gwa /usr/local/bin/
           CLIENT_ID=$(echo "$GWA_ACCT" | jq -r '.client_id')
           CLIENT_SECRET=$(echo "$GWA_ACCT" | jq -r '.client_secret')
           gwa login --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET"
           gwa config set gateway gw-fe8c5
-          # Apply ONLY the prod GatewayService (single qualifier tag ns.gw-fe8c5.prod). The tag
-          # scopes the reconcile so DEV/TEST routes are left untouched.
-          echo "Applying PROD gateway config…"
+          # Publish the prod qualifier as a partial set. --qualifier scopes the reconcile so
+          # DEV/TEST (other qualifiers) are left untouched.
+          echo "Publishing PROD gateway config (qualifier=prod)…"
           set +e
-          OUT=$(gwa apply -i api-gateway/generated/gw-routes-prod.yaml 2>&1)
+          OUT=$(gwa publish-gateway api-gateway/generated/gw-kong-prod.yaml --qualifier prod 2>&1)
           STATUS=$?
           set -e
           echo "$OUT"
           # gwa can exit 0 even when the publish is rejected — fail on non-zero exit or rejection markers.
-          if [ "$STATUS" -ne 0 ] || echo "$OUT" | grep -qiE "publish failed|Errors encountered|Rejecting request|Validation Errors"; then
-            echo "::error::gwa apply failed for the prod gateway config"
+          if [ "$STATUS" -ne 0 ] || echo "$OUT" | grep -qiE "publish failed|Errors encountered|Rejecting request|Validation Errors|Sync Failed"; then
+            echo "::error::gwa publish-gateway failed for qualifier=prod"
             exit 1
           fi
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -123,7 +123,7 @@ jobs:
       tag: ${{ github.event.number }}
       db_user: app-${{ github.event.number }}
       params: --set global.secrets.persist=false --set frontend.secrets.enabled=true --set backend.clamav.enabled=false --set backend.clamav.host=common-notify-dev-clamav
-      triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/workflows/.deployer.yml')
+      triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' 'api-gateway/' '.github/workflows/.deployer.yml')
       db_triggers: ('charts/crunchy/')
       redis_triggers: ('charts/redis/')
 

--- a/api-gateway/scripts/generate-gateway-for-stage.sh
+++ b/api-gateway/scripts/generate-gateway-for-stage.sh
@@ -20,7 +20,7 @@ case "$STAGE" in
   dev)
     echo "Generating gateway config for: DEV only"
     echo ""
-    echo "⚠️  This will DELETE TEST and PROD gateway routes!"
+    echo "TEST and PROD are published separately under their own qualifiers and are not affected."
     echo ""
 
     # Generate DEV only
@@ -36,7 +36,7 @@ case "$STAGE" in
   test)
     echo "Generating gateway config for: DEV + TEST"
     echo ""
-    echo "⚠️  This will DELETE PROD gateway routes!"
+    echo "PROD is published separately under its own qualifier and is not affected."
     echo ""
 
     # Generate both DEV and TEST

--- a/api-gateway/scripts/gwservice-to-kong.py
+++ b/api-gateway/scripts/gwservice-to-kong.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Convert gwa `kind: GatewayService` documents into a raw Kong/deck config that
+`gwa publish-gateway` accepts.
+
+Why this exists:
+  - `gwa apply` publishes a `kind: GatewayService` resource but sends NO qualifier,
+    so it cannot reconcile qualifier-scoped entities (it 409s trying to re-create
+    services that already exist, and silently no-ops on updates).
+  - `gwa publish-gateway --qualifier <env>` reconciles the qualifier-scoped set
+    correctly, but it requires a raw Kong/deck config (services -> routes -> plugins),
+    not the `kind: GatewayService` wrapper.
+
+What this does:
+  - Unwraps each `GatewayService` into a Kong `service` (routes stay nested).
+  - Nests each top-level plugin under its target route (or service) — deck rejects
+    top-level plugins here ("Invalid base entity plugins").
+  - Forces `strip_path: false` on every route. The backend (NestJS, global prefix
+    /api + version v1) expects the full `/api/v1/...` path; a literal `strip_path: true`
+    strips it and the backend returns `Cannot POST /` (404). The gwa-api's own apply
+    path does not strip, so this restores the working behaviour.
+
+Usage:
+  python3 gwservice-to-kong.py <gw-routes-file.yaml> > <gw-kong-file.yaml>
+"""
+import sys
+import yaml
+
+
+def convert(path):
+    services, plugins = [], []
+    for doc in yaml.safe_load_all(open(path)):
+        if not doc:
+            continue
+        if doc.get("kind") == "GatewayService":
+            services.append({k: v for k, v in doc.items() if k not in ("kind", "plugins")})
+            plugins.extend(doc.get("plugins", []) or [])
+        else:
+            sys.stderr.write(f"WARN skipping unsupported kind={doc.get('kind')!r}\n")
+
+    svc_by_name = {s["name"]: s for s in services}
+    route_by_name = {}
+    for svc in services:
+        for route in svc.get("routes", []) or []:
+            route["strip_path"] = False
+            route_by_name[route["name"]] = route
+
+    unresolved = []
+    for plugin in plugins:
+        body = {k: v for k, v in plugin.items() if k not in ("route", "service")}
+        target = route_by_name.get(plugin.get("route")) or svc_by_name.get(plugin.get("service"))
+        if target is None:
+            unresolved.append(plugin.get("route") or plugin.get("service") or "?")
+            continue
+        target.setdefault("plugins", []).append(body)
+
+    if unresolved:
+        sys.stderr.write(
+            f"WARN {len(unresolved)} plugin(s) had no matching route/service: {unresolved[:5]}\n"
+        )
+
+    return {"_format_version": "3.0", "services": services}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: gwservice-to-kong.py <gw-routes-file.yaml>\n")
+        sys.exit(2)
+    yaml.safe_dump(convert(sys.argv[1]), sys.stdout, sort_keys=False, width=4096)


### PR DESCRIPTION
Qualifiers are used (dev, test, and prod) when applying api gateway routes, so no longer need to delete routes and recreate them in other environments.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-173.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-173.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)