### PR TITLE
fix: add missing product.env for gateway config generation

### DIFF
--- a/api-gateway/config/product.env
+++ b/api-gateway/config/product.env
@@ -1,0 +1,5 @@
+# Product Gateway Configuration
+# Used for gwa product definition
+
+GATEWAY_ID=gw-fe8c5
+ENVIRONMENT=prod


### PR DESCRIPTION
## Problem
pr-close.yml workflow fails when closing PRs with this error:
```
/api-gateway/config/product.env: No such file or directory
```

## Root Cause
- pr-close.yml (on main) calls `generate-gateway-for-stage.sh prod`
- That script calls `generate-gateway-config.sh all`
- Which tries to source `api-gateway/config/product.env`
- File doesn't exist!

## Solution
Add the missing product.env file with minimal required config.

## Testing
- File added with GATEWAY_ID and ENVIRONMENT variables
- Will allow pr-close workflow to complete successfully

## Related
- Failed run: https://github.com/bcgov/common-notify/actions/runs/30934078807/job/92075674601
- PR #184 (gateway fixes) will replace this workflow entirely once merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-188.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-188.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)