### PR TITLE
fix: derive release version from git tag and bump minor every merge

### DIFF
--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 set -e
 
-# Script to automatically bump version based on conventional commits
+# Script to bump the release version, derived from the latest git tag.
 # Usage: ./bump-version.sh [major|minor|patch|auto]
 #
-# Auto mode (default): Analyzes commits since last tag
-#   - feat: commits -> minor bump (automatic)
-#   - fix: commits -> patch bump (automatic)
-#   - BREAKING CHANGE or major: -> requires manual major bump
+# The latest git tag (vX.Y.Z) is the single source of truth for the current
+# version — NOT frontend/package.json — so the version always advances on every
+# merge without needing to commit package.json back to main.
+#
+#   auto (default): minor bump on every run (project policy: minor per merge).
+#   minor:          X.Y.Z -> X.(Y+1).0
+#   patch:          X.Y.Z -> X.Y.(Z+1)
+#   major:          (X+1).0.0   (must be requested explicitly)
 
 BUMP_TYPE="${1:-auto}"
 PACKAGE_JSON="frontend/package.json"
@@ -18,47 +22,28 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Get current version from package.json
-CURRENT_VERSION=$(node -p "require('./$PACKAGE_JSON').version")
+# Derive the current version from the latest git tag (source of truth).
+# Fall back to package.json, then 0.0.0, when no tag exists yet.
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+  CURRENT_VERSION="${LAST_TAG#v}"   # strip leading "v"
+  echo "Latest tag: $LAST_TAG"
+else
+  CURRENT_VERSION=$(node -p "require('./$PACKAGE_JSON').version" 2>/dev/null || echo "0.0.0")
+  echo -e "${YELLOW}No previous tag found. Falling back to package.json version.${NC}"
+fi
 echo "Current version: $CURRENT_VERSION"
 
 # Parse version into parts
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+MAJOR="${MAJOR:-0}"
+MINOR="${MINOR:-0}"
+PATCH="${PATCH:-0}"
 
-# Get the last tag to analyze commits since then
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
-if [ -z "$LAST_TAG" ]; then
-  echo -e "${YELLOW}No previous tag found. Using initial commits.${NC}"
-  COMMITS=$(git log --pretty=format:"%s")
-else
-  echo "Last tag: $LAST_TAG"
-  COMMITS=$(git log "$LAST_TAG"..HEAD --pretty=format:"%s")
-fi
-
-# Determine bump type if auto mode
+# Auto mode: project policy is a minor bump on every merge.
 if [ "$BUMP_TYPE" == "auto" ]; then
-  # Check for breaking changes
-  if echo "$COMMITS" | grep -qiE "^(BREAKING CHANGE|major:)"; then
-    echo -e "${RED}⚠️  BREAKING CHANGE detected!${NC}"
-    echo -e "${RED}Major version bumps must be done manually.${NC}"
-    echo -e "${RED}Please run: ./bump-version.sh major${NC}"
-    exit 1
-  fi
-
-  # Check for features (minor bump)
-  if echo "$COMMITS" | grep -qiE "^feat(\(|:)"; then
-    BUMP_TYPE="minor"
-    echo -e "${GREEN}Feature commits detected -> minor bump${NC}"
-  # Check for fixes (patch bump)
-  elif echo "$COMMITS" | grep -qiE "^fix(\(|:)"; then
-    BUMP_TYPE="patch"
-    echo -e "${GREEN}Fix commits detected -> patch bump${NC}"
-  else
-    # No conventional commits found - default to patch
-    BUMP_TYPE="patch"
-    echo -e "${YELLOW}No conventional commits found -> defaulting to patch bump${NC}"
-  fi
+  BUMP_TYPE="minor"
+  echo -e "${GREEN}Auto mode -> minor bump (one minor version per merge)${NC}"
 fi
 
 # Calculate new version
@@ -91,7 +76,9 @@ esac
 NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
 echo "New version: $NEW_VERSION"
 
-# Update package.json using node
+# Update package.json so the workspace reflects the new version (used by the
+# release step to read the version). This is not committed back — the git tag
+# remains the source of truth.
 node -e "
 const fs = require('fs');
 const pkg = JSON.parse(fs.readFileSync('$PACKAGE_JSON', 'utf8'));


### PR DESCRIPTION
The release tag was frozen at v1.1.0: bump-version.sh read/wrote frontend/package.json, but the create-release job only pushed the git tag and never committed the bumped package.json back to main. main stayed at 1.0.0, so every run recomputed 1.1.0 and the 'Check if Tag Exists' guard skipped the release after the first time.

Make the latest git tag the single source of truth:
- Derive the current version from 'git describe --tags' (fall back to package.json, then 0.0.0, when no tag exists) instead of package.json, so the version advances without committing anything back to main.
- Auto mode now always does a minor bump (project policy: one minor version per merge): v1.1.0 -> 1.2.0 -> 1.3.0 ...
- Keep major/minor/patch args working; package.json is still updated in the workspace for the release step to read, but not committed.

Verified locally against tag v1.1.0: auto->1.2.0, patch->1.1.1, major->2.0.0.

<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [x] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-195.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-195.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)