### PR TITLE
feat: ccp-5463-add-ability-to-delete-templates

### DIFF
--- a/backend/src/api/templates/entities/template.entity.ts
+++ b/backend/src/api/templates/entities/template.entity.ts
@@ -119,6 +119,12 @@ export class Template {
   active: boolean
 
   /**
+   * Timestamp when the template was soft-deleted
+   */
+  @Column({ name: 'deleted_at', type: 'timestamptz', nullable: true })
+  deletedAt?: Date | null
+
+  /**
    * User or process that created this template
    */
   @Column({ name: 'created_by', length: 200 })

--- a/backend/src/api/templates/templates.repository.spec.ts
+++ b/backend/src/api/templates/templates.repository.spec.ts
@@ -77,14 +77,14 @@ describe('TemplatesRepository', () => {
   })
 
   describe('findById', () => {
-    it('should find a template by ID and tenant ID', async () => {
+    it('should find an active template by ID and tenant ID', async () => {
       mockTemplateRepository.findOne.mockResolvedValue(mockTemplate)
 
       const result = await repository.findById('tenant-123', 'template-123')
 
       expect(result).toEqual(mockTemplate)
       expect(mockTemplateRepository.findOne).toHaveBeenCalledWith({
-        where: { id: 'template-123', tenantId: 'tenant-123' },
+        where: { id: 'template-123', tenantId: 'tenant-123', active: true },
         relations: ['channel', 'engine'],
       })
     })

--- a/backend/src/api/templates/templates.repository.spec.ts
+++ b/backend/src/api/templates/templates.repository.spec.ts
@@ -367,13 +367,14 @@ describe('TemplatesRepository', () => {
   })
 
   describe('softDelete', () => {
-    it('should mark a template as inactive', async () => {
+    it('should mark a template as inactive and record the deletion time', async () => {
       mockTemplateRepository.update.mockResolvedValue({ affected: 1 })
 
       await repository.softDelete('template-123')
 
       expect(mockTemplateRepository.update).toHaveBeenCalledWith('template-123', {
         active: false,
+        deletedAt: expect.any(Date),
       })
     })
 
@@ -384,6 +385,7 @@ describe('TemplatesRepository', () => {
 
       expect(mockTemplateRepository.update).toHaveBeenCalledWith('non-existent', {
         active: false,
+        deletedAt: expect.any(Date),
       })
     })
   })

--- a/backend/src/api/templates/templates.repository.ts
+++ b/backend/src/api/templates/templates.repository.ts
@@ -20,11 +20,11 @@ export class TemplatesRepository {
   ) {}
 
   /**
-   * Find a template by ID and tenant ID
+   * Find an active template by ID and tenant ID
    */
   async findById(tenantId: string, templateId: string): Promise<Template | null> {
     return this.templateRepository.findOne({
-      where: { id: templateId, tenantId },
+      where: { id: templateId, tenantId, active: true },
       relations: ['channel', 'engine'],
     })
   }

--- a/backend/src/api/templates/templates.repository.ts
+++ b/backend/src/api/templates/templates.repository.ts
@@ -156,7 +156,10 @@ export class TemplatesRepository {
    * Soft delete a template (mark as inactive)
    */
   async softDelete(templateId: string): Promise<void> {
-    await this.templateRepository.update(templateId, { active: false })
+    await this.templateRepository.update(templateId, {
+      active: false,
+      deletedAt: new Date(),
+    })
   }
 
   /**

--- a/migrations/sql/V47__add_template_deleted_at.sql
+++ b/migrations/sql/V47__add_template_deleted_at.sql
@@ -1,0 +1,4 @@
+ALTER TABLE notify.template
+ADD COLUMN deleted_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN notify.template.deleted_at IS 'Timestamp when the template was soft-deleted.';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Adds backend support for soft-deleting templates
Templates are soft-deleted by marking them as inactive and recording the time they were deleted. Deleted templates are excluded when retrieving templates by ID, preventing them from being accessed or used through API flows that rely on the template lookup.
Template list queries already filter for active templates, so deleted templates will not appear in template lists or dashboard data.

Frontend changes are out of scope for this PR and will be handled in a separate ticket.

Added a nullable deleted_at timestamp to the notify.template table.
Added deletedAt to the Template entity.
Updated template soft-delete behavior to:
Set active to false.
Record the deletion timestamp in deleted_at.
Updated template lookup by ID to return active templates only.
Updated repository unit tests for the new soft-delete and active-template lookup behavior.
Added database migration V47__add_template_deleted_at.sql.
Fixes # CCP-5463

## Type of change

<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-200.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-200.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)