### PR TITLE
fix: Redis OOM crash loop + add pod-state/memory alerting (Prometheus + KSM)

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -120,6 +120,7 @@ jobs:
               --namespace ${{ secrets.OC_DEV_NAMESPACE }} \
               --values monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml \
               --wait --timeout 5m
+            oc apply -f monitoring/grafana-stack/prometheus/networkpolicy-ksm-appns.yaml -n ${{ secrets.OC_DEV_NAMESPACE }}
             oc get pods -n ${{ secrets.OC_DEV_NAMESPACE }} -l app.kubernetes.io/name=kube-state-metrics
 
   deploy-ksm-test:
@@ -145,6 +146,7 @@ jobs:
               --namespace ${{ secrets.OC_TEST_NAMESPACE }} \
               --values monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml \
               --wait --timeout 5m
+            oc apply -f monitoring/grafana-stack/prometheus/networkpolicy-ksm-appns.yaml -n ${{ secrets.OC_TEST_NAMESPACE }}
             oc get pods -n ${{ secrets.OC_TEST_NAMESPACE }} -l app.kubernetes.io/name=kube-state-metrics
 
   deploy-ksm-prod:
@@ -170,6 +172,7 @@ jobs:
               --namespace ${{ secrets.OC_PROD_NAMESPACE }} \
               --values monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml \
               --wait --timeout 5m
+            oc apply -f monitoring/grafana-stack/prometheus/networkpolicy-ksm-appns.yaml -n ${{ secrets.OC_PROD_NAMESPACE }}
             oc get pods -n ${{ secrets.OC_PROD_NAMESPACE }} -l app.kubernetes.io/name=kube-state-metrics
 
   deploy-prometheus-centralized:

--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -93,12 +93,94 @@ jobs:
             # Verify
             oc get pods -n ${NAMESPACE} -l app.kubernetes.io/name=loki
 
-  deploy-prometheus-centralized:
-    name: Deploy Prometheus (Centralized - Tools)
+  # kube-state-metrics is deployed PER APP NAMESPACE using that namespace's own
+  # token (like the grafana-agent jobs), because BC Gov tenants cannot create
+  # cluster-scoped RBAC and the pipeline SA cannot create RBAC cross-namespace.
+  # Central Prometheus (below) scrapes these via static DNS.
+  deploy-ksm-dev:
+    name: Deploy kube-state-metrics (Dev)
     if: |
       (github.event_name == 'workflow_dispatch' && inputs.deployment_mode == 'centralized' &&
        (inputs.component == 'all' || inputs.component == 'prometheus')) ||
       (github.event_name == 'push')
+    runs-on: ubuntu-24.04
+    environment: DEV
+    steps:
+      - uses: actions/checkout@v6
+      - name: Deploy kube-state-metrics to Dev
+        uses: bcgov/action-oc-runner@111868d1fc50db0a40417ba321d865ef5c931bbd # v1.7.0
+        with:
+          oc_namespace: ${{ secrets.OC_DEV_NAMESPACE }}
+          oc_token: ${{ secrets.OC_DEV_TOKEN }}
+          oc_server: ${{ vars.oc_server }}
+          commands: |
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
+            helm repo update
+            helm upgrade --install ksm prometheus-community/kube-state-metrics \
+              --namespace ${{ secrets.OC_DEV_NAMESPACE }} \
+              --values monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml \
+              --wait --timeout 5m
+            oc get pods -n ${{ secrets.OC_DEV_NAMESPACE }} -l app.kubernetes.io/name=kube-state-metrics
+
+  deploy-ksm-test:
+    name: Deploy kube-state-metrics (Test)
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deployment_mode == 'centralized' &&
+       (inputs.component == 'all' || inputs.component == 'prometheus')) ||
+      (github.event_name == 'push')
+    runs-on: ubuntu-24.04
+    environment: TEST
+    steps:
+      - uses: actions/checkout@v6
+      - name: Deploy kube-state-metrics to Test
+        uses: bcgov/action-oc-runner@111868d1fc50db0a40417ba321d865ef5c931bbd # v1.7.0
+        with:
+          oc_namespace: ${{ secrets.OC_TEST_NAMESPACE }}
+          oc_token: ${{ secrets.OC_TEST_TOKEN }}
+          oc_server: ${{ vars.oc_server }}
+          commands: |
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
+            helm repo update
+            helm upgrade --install ksm prometheus-community/kube-state-metrics \
+              --namespace ${{ secrets.OC_TEST_NAMESPACE }} \
+              --values monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml \
+              --wait --timeout 5m
+            oc get pods -n ${{ secrets.OC_TEST_NAMESPACE }} -l app.kubernetes.io/name=kube-state-metrics
+
+  deploy-ksm-prod:
+    name: Deploy kube-state-metrics (Prod)
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deployment_mode == 'centralized' &&
+       (inputs.component == 'all' || inputs.component == 'prometheus')) ||
+      (github.event_name == 'push')
+    runs-on: ubuntu-24.04
+    environment: PROD
+    steps:
+      - uses: actions/checkout@v6
+      - name: Deploy kube-state-metrics to Prod
+        uses: bcgov/action-oc-runner@111868d1fc50db0a40417ba321d865ef5c931bbd # v1.7.0
+        with:
+          oc_namespace: ${{ secrets.OC_PROD_NAMESPACE }}
+          oc_token: ${{ secrets.OC_PROD_TOKEN }}
+          oc_server: ${{ vars.oc_server }}
+          commands: |
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
+            helm repo update
+            helm upgrade --install ksm prometheus-community/kube-state-metrics \
+              --namespace ${{ secrets.OC_PROD_NAMESPACE }} \
+              --values monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml \
+              --wait --timeout 5m
+            oc get pods -n ${{ secrets.OC_PROD_NAMESPACE }} -l app.kubernetes.io/name=kube-state-metrics
+
+  deploy-prometheus-centralized:
+    name: Deploy Prometheus (Centralized - Tools)
+    needs: [deploy-ksm-dev, deploy-ksm-test, deploy-ksm-prod]
+    if: |
+      !cancelled() &&
+      (needs.deploy-ksm-dev.result == 'success' || needs.deploy-ksm-dev.result == 'skipped') &&
+      ((github.event_name == 'workflow_dispatch' && inputs.deployment_mode == 'centralized' &&
+        (inputs.component == 'all' || inputs.component == 'prometheus')) ||
+       (github.event_name == 'push'))
     runs-on: ubuntu-24.04
     environment: TOOLS
     steps:
@@ -112,7 +194,7 @@ jobs:
           oc_server: ${{ vars.oc_server }}
           commands: |
             NAMESPACE="${{ secrets.OC_TOOLS_NAMESPACE }}"
-            echo "📊 Deploying Prometheus + kube-state-metrics to ${NAMESPACE} (metric-based alerting)"
+            echo "📊 Deploying central Prometheus to ${NAMESPACE} (scrapes per-namespace kube-state-metrics via static DNS)"
 
             helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
             helm repo update

--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -28,6 +28,7 @@ on:
         options:
           - all
           - loki
+          - prometheus
           - grafana
           - grafana-agent
         default: 'all'
@@ -92,12 +93,50 @@ jobs:
             # Verify
             oc get pods -n ${NAMESPACE} -l app.kubernetes.io/name=loki
 
+  deploy-prometheus-centralized:
+    name: Deploy Prometheus (Centralized - Tools)
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deployment_mode == 'centralized' &&
+       (inputs.component == 'all' || inputs.component == 'prometheus')) ||
+      (github.event_name == 'push')
+    runs-on: ubuntu-24.04
+    environment: TOOLS
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy Prometheus to Tools Namespace
+        uses: bcgov/action-oc-runner@111868d1fc50db0a40417ba321d865ef5c931bbd # v1.7.0
+        with:
+          oc_namespace: ${{ secrets.OC_TOOLS_NAMESPACE }}
+          oc_token: ${{ secrets.OC_TOOLS_TOKEN }}
+          oc_server: ${{ vars.oc_server }}
+          commands: |
+            NAMESPACE="${{ secrets.OC_TOOLS_NAMESPACE }}"
+            echo "📊 Deploying Prometheus + kube-state-metrics to ${NAMESPACE} (metric-based alerting)"
+
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
+            helm repo update
+
+            helm upgrade --install prometheus prometheus-community/prometheus \
+              --namespace ${NAMESPACE} \
+              --values monitoring/grafana-stack/prometheus/values-tools.yaml \
+              --wait \
+              --timeout 10m
+
+            echo "✅ Prometheus deployed successfully"
+
+            echo "🔒 Applying Prometheus NetworkPolicies..."
+            oc apply -f monitoring/grafana-stack/prometheus/networkpolicy-tools.yaml
+
+            oc get pods -n ${NAMESPACE} -l app.kubernetes.io/name=prometheus
+
   deploy-grafana-centralized:
     name: Deploy Grafana (Centralized - Tools)
-    needs: [deploy-loki-centralized]
+    needs: [deploy-loki-centralized, deploy-prometheus-centralized]
     if: |
       !cancelled() &&
-      (needs.deploy-loki-centralized.result == 'success' || needs.deploy-loki-centralized.result == 'skipped')
+      (needs.deploy-loki-centralized.result == 'success' || needs.deploy-loki-centralized.result == 'skipped') &&
+      (needs.deploy-prometheus-centralized.result == 'success' || needs.deploy-prometheus-centralized.result == 'skipped')
     runs-on: ubuntu-24.04
     environment: TOOLS
     steps:

--- a/charts/redis/values.yml
+++ b/charts/redis/values.yml
@@ -24,13 +24,16 @@ redis:
       enabled: true
       size: 1Gi
       storageClass: netapp-block-standard
+    # Sized for the Bull/BullMQ job queue (~67k keys) plus RediSearch + ReJSON
+    # modules and replication resync headroom. 512Mi OOM-looped in dev (CCP: redis
+    # OOMKilled x300+). maxmemory (in commonConfiguration) caps usage below the limit.
     resources:
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 512Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi
   replica:
     shareProcessNamespace: true
     replicaCount: 2
@@ -50,13 +53,15 @@ redis:
       accessMode: ReadWriteOnce
       size: 1Gi
       storageClass: netapp-block-standard
+    # Match master sizing — replicas load the full dataset and perform full resync,
+    # which is when memory peaks. 512Mi OOM-looped in dev.
     resources:
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 512Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi
   sentinel:
     enabled: true
     quorum: 1
@@ -94,6 +99,14 @@ redis:
     appendfilename "appendonly.aof"
     # Disable RDB persistence
     save ""
+    # Cap Redis memory BELOW the 1Gi container limit so Redis manages memory itself
+    # instead of being OOMKilled by the kernel (which caused a 300+ restart crash loop).
+    # Headroom (1Gi - 768mb) covers RediSearch/ReJSON module overhead and resync buffers.
+    maxmemory 768mb
+    # This Redis backs a durable Bull/BullMQ job queue (ingestion/email/sms), NOT a
+    # disposable cache. noeviction => reject new writes when full rather than silently
+    # dropping queued jobs. If writes start failing, raise the limit — do not switch to LRU.
+    maxmemory-policy noeviction
   metrics:
     enabled: true
     podSecurityContext:

--- a/monitoring/grafana-stack/grafana/infra-alert-rules.yaml
+++ b/monitoring/grafana-stack/grafana/infra-alert-rules.yaml
@@ -7,23 +7,32 @@
 #   permanent dev backend and the redis pods have crash-looped for days with
 #   hundreds of restarts and nothing fired.
 #
-#   These rules are METRIC-based, evaluated by Grafana against the platform
-#   Prometheus (via the "Thanos" datasource, see datasources block below).
-#   They route to the existing `common-notify-email` contact point (n8n webhook),
-#   so no new delivery wiring is needed.
+#   These rules are METRIC-based, evaluated by Grafana against the in-namespace
+#   Prometheus (datasource UID "prometheus", deployed via
+#   monitoring/grafana-stack/prometheus/values-tools.yaml). They route to the
+#   existing `common-notify-email` contact point (n8n webhook) — delivery is
+#   already wired, so no new notification setup is needed.
 #
-# DATA SOURCE
-#   Requires the "Thanos" Prometheus datasource (added in values-tools-sso.yaml).
-#   Metrics used are standard OpenShift platform metrics:
+# DATA SOURCE  (UID: prometheus — keep in sync with values-tools-sso.yaml)
+#   Metrics from kube-state-metrics (bundled with the Prometheus chart):
 #     - kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"}
 #     - kube_pod_container_status_restarts_total
 #     - kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}
-#     - container_memory_working_set_bytes / kube_pod_container_resource_limits
-#     - kube_deployment_status_replicas_available vs _replicas
+#     - kube_pod_container_resource_limits{resource="memory"}
+#     - kube_pod_status_phase, kube_deployment_status_replicas_available
+#
+# ⚠️ MEMORY-USAGE-% CAVEAT
+#   The two memory-USAGE rules (cn-mem-high / cn-mem-critical) use
+#   container_memory_working_set_bytes, which comes from cAdvisor/kubelet — NOT
+#   kube-state-metrics. A namespace-scoped Prometheus may NOT be able to scrape
+#   the kubelet (needs node-level RBAC). If those metrics are absent, those two
+#   rules simply never fire (no error). The OOMKilled rule (cn-oomkilled) is the
+#   reliable memory signal — it comes from kube-state-metrics and always works.
+#   If cAdvisor metrics are unavailable, treat cn-oomkilled as the primary memory
+#   alert and drop/disable the two usage-% rules.
 #
 # SCOPE
 #   Namespaces f6bc3f-dev|test|prod. App workloads (backend/frontend/redis/db).
-#   Datasource UID referenced as `thanos` — keep in sync with the datasource.
 # ---------------------------------------------------------------------------
 
 apiVersion: 1
@@ -43,7 +52,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |
@@ -79,7 +88,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 900, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |
@@ -113,7 +122,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |
@@ -148,7 +157,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |
@@ -190,7 +199,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |
@@ -228,7 +237,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |
@@ -266,7 +275,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 600, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |
@@ -308,7 +317,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange: { from: 600, to: 0 }
-            datasourceUid: thanos
+            datasourceUid: prometheus
             model:
               editorMode: code
               expr: |

--- a/monitoring/grafana-stack/grafana/infra-alert-rules.yaml
+++ b/monitoring/grafana-stack/grafana/infra-alert-rules.yaml
@@ -1,0 +1,342 @@
+# Grafana-managed infrastructure (pod-state / resource) alert rules
+# ---------------------------------------------------------------------------
+# WHY THIS FILE EXISTS
+#   The existing alerting (monitoring/grafana-stack/loki/alert-rules.yaml) is
+#   entirely LOG-BASED (Loki). Log rules cannot see Kubernetes pod state, so a
+#   CrashLoopBackOff / OOMKill / memory pressure produced NO alert — e.g. the
+#   permanent dev backend and the redis pods have crash-looped for days with
+#   hundreds of restarts and nothing fired.
+#
+#   These rules are METRIC-based, evaluated by Grafana against the platform
+#   Prometheus (via the "Thanos" datasource, see datasources block below).
+#   They route to the existing `common-notify-email` contact point (n8n webhook),
+#   so no new delivery wiring is needed.
+#
+# DATA SOURCE
+#   Requires the "Thanos" Prometheus datasource (added in values-tools-sso.yaml).
+#   Metrics used are standard OpenShift platform metrics:
+#     - kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"}
+#     - kube_pod_container_status_restarts_total
+#     - kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}
+#     - container_memory_working_set_bytes / kube_pod_container_resource_limits
+#     - kube_deployment_status_replicas_available vs _replicas
+#
+# SCOPE
+#   Namespaces f6bc3f-dev|test|prod. App workloads (backend/frontend/redis/db).
+#   Datasource UID referenced as `thanos` — keep in sync with the datasource.
+# ---------------------------------------------------------------------------
+
+apiVersion: 1
+groups:
+  # =========================================================================
+  # POD STATE — the category that was completely missing
+  # =========================================================================
+  - orgId: 1
+    name: pod-state
+    folder: Common Notify Infra
+    interval: 1m
+    rules:
+      - uid: cn-pod-crashloop
+        title: PodCrashLoopBackOff
+        condition: C
+        for: 2m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                max by (namespace, pod, container) (
+                  kube_pod_container_status_waiting_reason{
+                    namespace=~"f6bc3f-(dev|test|prod)",
+                    reason="CrashLoopBackOff"
+                  }
+                )
+              instant: true
+              intervalMs: 1000
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+              refId: C
+        labels:
+          severity: critical
+          service: common-notify
+          component: pod-state
+        annotations:
+          summary: "CrashLoopBackOff: {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})"
+          description: "Container {{ $labels.container }} in pod {{ $labels.pod }} ({{ $labels.namespace }}) is in CrashLoopBackOff. It is repeatedly starting and crashing."
+
+      - uid: cn-pod-restarts-high
+        title: PodRestartsHigh
+        condition: C
+        for: 5m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                sum by (namespace, pod, container) (
+                  increase(kube_pod_container_status_restarts_total{
+                    namespace=~"f6bc3f-(dev|test|prod)"
+                  }[15m])
+                )
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [3] }
+              refId: C
+        labels:
+          severity: warning
+          service: common-notify
+          component: pod-state
+        annotations:
+          summary: "Frequent restarts: {{ $labels.namespace }}/{{ $labels.pod }}"
+          description: "Container {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.namespace }}) restarted more than 3 times in the last 15 minutes."
+
+      - uid: cn-pod-not-ready
+        title: PodNotReady
+        condition: C
+        for: 10m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                sum by (namespace, pod) (
+                  kube_pod_status_phase{
+                    namespace=~"f6bc3f-(dev|test|prod)",
+                    phase=~"Pending|Unknown|Failed"
+                  }
+                ) > 0
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+              refId: C
+        labels:
+          severity: warning
+          service: common-notify
+          component: pod-state
+        annotations:
+          summary: "Pod not ready: {{ $labels.namespace }}/{{ $labels.pod }}"
+          description: "Pod {{ $labels.pod }} in {{ $labels.namespace }} has been in a non-running phase for over 10 minutes."
+
+      - uid: cn-deployment-replicas
+        title: DeploymentReplicasMismatch
+        condition: C
+        for: 10m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                (
+                  kube_deployment_status_replicas_available{namespace=~"f6bc3f-(dev|test|prod)"}
+                  <
+                  kube_deployment_spec_replicas{namespace=~"f6bc3f-(dev|test|prod)"}
+                )
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+              refId: C
+        labels:
+          severity: warning
+          service: common-notify
+          component: pod-state
+        annotations:
+          summary: "Deployment under-replicated: {{ $labels.namespace }}/{{ $labels.deployment }}"
+          description: "Deployment {{ $labels.deployment }} in {{ $labels.namespace }} has fewer available replicas than desired for 10+ minutes."
+
+  # =========================================================================
+  # MEMORY / OOM — the memory check you asked for. Limits are 8Gi per container.
+  # =========================================================================
+  - orgId: 1
+    name: memory
+    folder: Common Notify Infra
+    interval: 1m
+    rules:
+      - uid: cn-mem-high
+        title: ContainerMemoryHigh
+        condition: C
+        for: 10m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                max by (namespace, pod, container) (
+                  container_memory_working_set_bytes{
+                    namespace=~"f6bc3f-(dev|test|prod)", container!="", container!="POD"
+                  }
+                  /
+                  kube_pod_container_resource_limits{
+                    namespace=~"f6bc3f-(dev|test|prod)", resource="memory"
+                  }
+                ) * 100
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [85] }
+              refId: C
+        labels:
+          severity: warning
+          service: common-notify
+          component: memory
+        annotations:
+          summary: "High memory: {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})"
+          description: "Container {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.namespace }}) is using {{ printf \"%.0f\" $values.A.Value }}% of its memory limit (threshold 85%). Risk of OOMKill."
+
+      - uid: cn-mem-critical
+        title: ContainerMemoryCritical
+        condition: C
+        for: 5m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                max by (namespace, pod, container) (
+                  container_memory_working_set_bytes{
+                    namespace=~"f6bc3f-(dev|test|prod)", container!="", container!="POD"
+                  }
+                  /
+                  kube_pod_container_resource_limits{
+                    namespace=~"f6bc3f-(dev|test|prod)", resource="memory"
+                  }
+                ) * 100
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [95] }
+              refId: C
+        labels:
+          severity: critical
+          service: common-notify
+          component: memory
+        annotations:
+          summary: "CRITICAL memory: {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})"
+          description: "Container {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.namespace }}) is above 95% of its memory limit and likely to be OOMKilled imminently."
+
+      - uid: cn-oomkilled
+        title: ContainerOOMKilled
+        condition: C
+        for: 1m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                sum by (namespace, pod, container) (
+                  increase(kube_pod_container_status_last_terminated_reason{
+                    namespace=~"f6bc3f-(dev|test|prod)", reason="OOMKilled"
+                  }[10m])
+                )
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+              refId: C
+        labels:
+          severity: critical
+          service: common-notify
+          component: memory
+        annotations:
+          summary: "OOMKilled: {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})"
+          description: "Container {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.namespace }}) was OOMKilled in the last 10 minutes. Increase memory limits or investigate a leak."
+
+  # =========================================================================
+  # CPU — throttling (limits are 4 CPU per container)
+  # =========================================================================
+  - orgId: 1
+    name: cpu
+    folder: Common Notify Infra
+    interval: 1m
+    rules:
+      - uid: cn-cpu-throttling
+        title: ContainerCPUThrottlingHigh
+        condition: C
+        for: 15m
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: thanos
+            model:
+              editorMode: code
+              expr: |
+                sum by (namespace, pod, container) (
+                  rate(container_cpu_cfs_throttled_periods_total{
+                    namespace=~"f6bc3f-(dev|test|prod)", container!="", container!="POD"
+                  }[5m])
+                )
+                /
+                sum by (namespace, pod, container) (
+                  rate(container_cpu_cfs_periods_total{
+                    namespace=~"f6bc3f-(dev|test|prod)", container!="", container!="POD"
+                  }[5m])
+                ) * 100 > 25
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [25] }
+              refId: C
+        labels:
+          severity: warning
+          service: common-notify
+          component: cpu
+        annotations:
+          summary: "CPU throttling: {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})"
+          description: "Container {{ $labels.container }} in {{ $labels.pod }} ({{ $labels.namespace }}) is being CPU-throttled >25% of the time for 15+ minutes."

--- a/monitoring/grafana-stack/grafana/values-tools-sso.yaml
+++ b/monitoring/grafana-stack/grafana/values-tools-sso.yaml
@@ -46,6 +46,18 @@ datasources:
         jsonData:
           manageAlerts: true
           alertmanagerUid: alertmanager
+      # Prometheus (in-namespace, deployed via monitoring/grafana-stack/prometheus).
+      # Source for the metric-based pod-state / OOM alerts (infra-alert-rules.yaml).
+      # UID "prometheus" is referenced by those rules' datasourceUid.
+      - name: Prometheus
+        type: prometheus
+        uid: prometheus
+        access: proxy
+        url: http://prometheus-server.f6bc3f-tools.svc.cluster.local
+        jsonData:
+          httpMethod: POST
+          manageAlerts: true
+          timeInterval: 30s
 
 # Alerting - Provision contact points and notification policies
 alerting:

--- a/monitoring/grafana-stack/grafana/values-tools-sso.yaml
+++ b/monitoring/grafana-stack/grafana/values-tools-sso.yaml
@@ -87,7 +87,7 @@ alerting:
                 **Summary:** {{ `{{ .Annotations.summary }}` }}
                 {{ `{{ if .Annotations.description }}` }}**Description:** {{ `{{ .Annotations.description }}{{ end }}` }}
 
-                **Status:** Firing for {{ `{{ .StartsAt | since }}` }}
+                **Status:** Firing since {{ `{{ .StartsAt }}` }}
                 [View in Grafana]({{ `{{ .GeneratorURL }}` }})
                 {{ `{{ end }}` }}
                 {{ `{{ end }}` }}
@@ -138,7 +138,7 @@ dashboardProviders:
 dashboards:
   default: {}
 
-# Sidecar for auto-loading dashboards
+# Sidecar for auto-loading dashboards and alert rules from ConfigMaps.
 sidecar:
   dashboards:
     enabled: true
@@ -149,6 +149,16 @@ sidecar:
     searchNamespace: f6bc3f-tools
     provider:
       foldersFromFilesStructure: false
+    resource: configmap
+  # Provision Grafana-managed alert rules from ConfigMaps labeled grafana_alert=1.
+  # Rules live in ConfigMaps (not inlined in these values) so their {{ $labels }}
+  # templates are NOT processed by Helm's tpl (which fails on "$labels").
+  # See monitoring/grafana-stack/grafana/infra-alert-rules.yaml.
+  alerts:
+    enabled: true
+    label: grafana_alert
+    labelValue: "1"
+    searchNamespace: f6bc3f-tools
     resource: configmap
 
 # Grafana configuration with SSO enabled

--- a/monitoring/grafana-stack/prometheus/networkpolicy-ksm-appns.yaml
+++ b/monitoring/grafana-stack/prometheus/networkpolicy-ksm-appns.yaml
@@ -1,0 +1,24 @@
+# Allow the central Prometheus (f6bc3f-tools) to scrape kube-state-metrics in an
+# app namespace. Apply this in EACH app namespace (dev/test/prod). Mirrors the
+# existing loki-ingress cross-namespace pattern (promtail dev/test/prod -> loki tools).
+#
+# Apply: oc apply -f networkpolicy-ksm-appns.yaml -n f6bc3f-<env>
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-tools-prometheus-to-ksm
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: f6bc3f-tools
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/monitoring/grafana-stack/prometheus/networkpolicy-tools.yaml
+++ b/monitoring/grafana-stack/prometheus/networkpolicy-tools.yaml
@@ -1,0 +1,25 @@
+# Network Policy for Prometheus in the tools namespace.
+# Allows Grafana (same namespace) to query Prometheus. Egress to the app
+# namespaces for scraping is generally permitted by default in these clusters;
+# add explicit egress rules here if the namespace enforces default-deny egress.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-ingress
+  namespace: f6bc3f-tools
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow Grafana (same namespace) to query the Prometheus server.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml
+++ b/monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml
@@ -1,0 +1,56 @@
+# kube-state-metrics — deployed PER APP NAMESPACE (dev/test/prod)
+# ---------------------------------------------------------------------------
+# WHY PER-NAMESPACE: BC Gov tenants cannot create cluster-scoped RBAC, and the
+# pipeline SA cannot create RBAC in dev/test/prod from tools. Deploying KSM into
+# each namespace with THAT namespace's own token (like the grafana-agent jobs)
+# lets it use namespaced RBAC (Role/RoleBinding in its own namespace) to read
+# pod/deployment state there.
+#
+# The central Prometheus in f6bc3f-tools scrapes each of these via static DNS:
+#   ksm-kube-state-metrics.<namespace>.svc.cluster.local:8080
+#
+# CHART: prometheus-community/kube-state-metrics
+# DEPLOY (per namespace, release name "ksm"):
+#   helm upgrade --install ksm prometheus-community/kube-state-metrics \
+#     -n <namespace> -f monitoring/grafana-stack/prometheus/values-kube-state-metrics.yaml
+# ---------------------------------------------------------------------------
+
+# Namespaced RBAC: Role/RoleBinding in the release namespace, no ClusterRole.
+rbac:
+  create: true
+  useClusterRole: false
+
+# Watch only the namespace this instance is deployed into.
+# (empty releaseNamespace defaults to the install namespace)
+namespaces: ""            # chart interprets empty as "release namespace only" in namespaced mode
+releaseNamespace: true
+
+# OpenShift assigns a random UID via SCC.
+securityContext:
+  enabled: true
+  runAsUser: null
+  runAsGroup: null
+  fsGroup: null
+  runAsNonRoot: true
+
+# Only the resource kinds our alerts use. No "nodes" (cluster-scoped).
+collectors:
+  - pods
+  - deployments
+  - replicasets
+  - statefulsets
+
+resources:
+  requests:
+    cpu: 20m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 256Mi
+
+# Small, single replica — this is per-namespace and low-cardinality.
+replicas: 1
+
+# The service the central Prometheus scrapes (port 8080 by default).
+service:
+  port: 8080

--- a/monitoring/grafana-stack/prometheus/values-tools.yaml
+++ b/monitoring/grafana-stack/prometheus/values-tools.yaml
@@ -1,0 +1,117 @@
+# Prometheus (+ kube-state-metrics) for Common Notify
+# ---------------------------------------------------------------------------
+# WHY: The monitoring stack was Loki-only (logs). Pod state (CrashLoopBackOff,
+# OOMKilled, restarts) and memory/CPU usage are METRICS, not logs — so a
+# crash loop produced no alert. This deploys a small Prometheus that scrapes
+# kube-state-metrics (pod/deployment state) and the app /metrics endpoints,
+# giving Grafana a metrics datasource for the infra-alert-rules.yaml alerts.
+#
+# CHART: prometheus-community/prometheus
+# SCOPE: f6bc3f-tools namespace. Short LOCAL retention (~10 days), no Thanos,
+#        no object storage. Alerting is handled by Grafana (contact point -> n8n),
+#        so Prometheus's own Alertmanager is disabled.
+# DEPLOY: helm upgrade --install prometheus prometheus-community/prometheus \
+#           -n f6bc3f-tools -f monitoring/grafana-stack/prometheus/values-tools.yaml
+# ---------------------------------------------------------------------------
+
+# --- Prometheus server ---
+server:
+  retention: 10d
+  # OpenShift assigns a random UID via SCC; leave user/group unset.
+  securityContext:
+    runAsUser: null
+    runAsNonRoot: true
+    runAsGroup: null
+    fsGroup: null
+  persistentVolume:
+    enabled: true
+    size: 10Gi
+    storageClass: netapp-file-standard
+    accessModes:
+      - ReadWriteOnce
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  # Scrape a bit less frequently than default to keep the footprint small.
+  global:
+    scrape_interval: 30s
+    scrape_timeout: 10s
+    evaluation_interval: 30s
+  service:
+    servicePort: 80
+  # No Prometheus-native alerting; Grafana owns alerts.
+  # (alertmanagers left empty by disabling the subchart below)
+
+# --- kube-state-metrics: the source of pod/deployment state metrics ---
+# This is what exposes kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"},
+# kube_pod_container_status_restarts_total, kube_pod_container_resource_limits, etc.
+kube-state-metrics:
+  enabled: true
+  securityContext:
+    enabled: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+    runAsNonRoot: true
+  resources:
+    requests:
+      cpu: 20m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
+  # Only collect the resource kinds we alert on — keeps cardinality/footprint low.
+  collectors:
+    - pods
+    - deployments
+    - replicasets
+    - statefulsets
+    - nodes
+
+# --- Components we do NOT need (keep the tools namespace light) ---
+alertmanager:
+  enabled: false          # Grafana handles alerting -> n8n
+prometheus-node-exporter:
+  enabled: false          # node-level metrics need host access / privileged SCC; not needed for pod-state alerts
+prometheus-pushgateway:
+  enabled: false
+
+# --- Scrape configuration ---
+# kube-state-metrics is auto-scraped by the chart's built-in job. Add the app
+# workloads' own /metrics (they carry prometheus.io/scrape annotations) so we
+# also get app-level metrics in dev/test/prod.
+extraScrapeConfigs: |
+  - job_name: 'common-notify-app-pods'
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - f6bc3f-dev
+            - f6bc3f-test
+            - f6bc3f-prod
+    relabel_configs:
+      # Only pods that opt in with prometheus.io/scrape: "true"
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      # Honour prometheus.io/path
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      # Honour prometheus.io/port
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        target_label: app

--- a/monitoring/grafana-stack/prometheus/values-tools.yaml
+++ b/monitoring/grafana-stack/prometheus/values-tools.yaml
@@ -18,14 +18,21 @@
 #       the same cross-namespace today).
 #
 # CHART: prometheus-community/prometheus
-# SCOPE: f6bc3f-tools. ~10d local retention, no Thanos, no object storage.
+# SCOPE: f6bc3f-tools. ~7d local retention (5Gi, fits the namespace storage quota),
+#        no Thanos, no object storage.
 #        Grafana owns alerting (-> n8n), so Prometheus Alertmanager is disabled.
 # DEPLOY: helm upgrade --install prometheus prometheus-community/prometheus \
 #           -n f6bc3f-tools -f monitoring/grafana-stack/prometheus/values-tools.yaml
 # ---------------------------------------------------------------------------
 
+# No cluster-scoped RBAC. BC Gov tenants cannot create ClusterRole/CRB, and this
+# Prometheus does not need the Kubernetes API — it scrapes everything via static
+# DNS (static_configs below), so no ClusterRole/ServiceDiscovery is required.
+rbac:
+  create: false
+
 server:
-  retention: 10d
+  retention: 7d
   securityContext:
     runAsUser: null
     runAsNonRoot: true
@@ -33,8 +40,12 @@ server:
     fsGroup: null
   persistentVolume:
     enabled: true
-    size: 10Gi
-    storageClass: netapp-file-standard
+    # f6bc3f-tools has an AGGREGATE storage-quota of 10Gi (all classes combined);
+    # Loki already uses 5Gi, leaving 5Gi. Block storage is a better fit for the
+    # Prometheus TSDB (RWO). 5Gi holds ~10d of these low-cardinality metrics
+    # (kube-state-metrics + a handful of app targets) comfortably.
+    size: 5Gi
+    storageClass: netapp-block-standard
     accessModes:
       - ReadWriteOnce
   resources:
@@ -66,15 +77,13 @@ prometheus-pushgateway:
 # so the Prometheus server needs NO Kubernetes API access at all.
 serverFiles:
   prometheus.yml:
-    global:
-      scrape_interval: 30s
-      scrape_timeout: 10s
-      evaluation_interval: 30s
+    # NOTE: do NOT set `global:` here — the chart injects its own global block
+    # from server.global, and a second one makes prometheus.yml invalid
+    # ("field global already set"). Only scrape_configs belongs here.
     scrape_configs:
-      # Prometheus scraping itself
-      - job_name: prometheus
-        static_configs:
-          - targets: ['localhost:9090']
+      # NOTE: the chart already defines a `prometheus` self-scrape job; do not
+      # redefine it here or config load fails ("multiple scrape configs with job
+      # name prometheus"). Helm merges this list with the chart defaults.
 
       # Per-namespace kube-state-metrics (pod/deployment state).
       # Service name is "<release>-kube-state-metrics"; released as "ksm" in each

--- a/monitoring/grafana-stack/prometheus/values-tools.yaml
+++ b/monitoring/grafana-stack/prometheus/values-tools.yaml
@@ -1,23 +1,31 @@
-# Prometheus (+ kube-state-metrics) for Common Notify
+# Central Prometheus for Common Notify (f6bc3f-tools)
 # ---------------------------------------------------------------------------
-# WHY: The monitoring stack was Loki-only (logs). Pod state (CrashLoopBackOff,
-# OOMKilled, restarts) and memory/CPU usage are METRICS, not logs — so a
-# crash loop produced no alert. This deploys a small Prometheus that scrapes
-# kube-state-metrics (pod/deployment state) and the app /metrics endpoints,
-# giving Grafana a metrics datasource for the infra-alert-rules.yaml alerts.
+# WHY: The stack was Loki-only (logs). Pod state (CrashLoopBackOff, OOMKilled,
+# restarts) and resource usage are METRICS, not logs — so a crash loop produced
+# no alert. This Prometheus gives Grafana a metrics datasource for the
+# infra-alert-rules.yaml alerts.
+#
+# RBAC-SAFE DESIGN (important):
+#   BC Gov tenants CANNOT create cluster-scoped RBAC (ClusterRole/CRB), and the
+#   pipeline SA cannot create RBAC in dev/test/prod from tools. So:
+#     - kube-state-metrics is NOT bundled here. It is deployed separately INTO
+#       each app namespace (values-kube-state-metrics.yaml) using that namespace's
+#       own token — exactly like the existing grafana-agent jobs. Namespaced RBAC.
+#     - This Prometheus does NOT use kubernetes_sd_configs (that needs cluster
+#       RBAC for pod discovery). It scrapes the per-namespace kube-state-metrics
+#       and the app /metrics via STATIC DNS (static_configs) — no k8s RBAC needed,
+#       only network reachability (same license plate, already allowed; Loki does
+#       the same cross-namespace today).
 #
 # CHART: prometheus-community/prometheus
-# SCOPE: f6bc3f-tools namespace. Short LOCAL retention (~10 days), no Thanos,
-#        no object storage. Alerting is handled by Grafana (contact point -> n8n),
-#        so Prometheus's own Alertmanager is disabled.
+# SCOPE: f6bc3f-tools. ~10d local retention, no Thanos, no object storage.
+#        Grafana owns alerting (-> n8n), so Prometheus Alertmanager is disabled.
 # DEPLOY: helm upgrade --install prometheus prometheus-community/prometheus \
 #           -n f6bc3f-tools -f monitoring/grafana-stack/prometheus/values-tools.yaml
 # ---------------------------------------------------------------------------
 
-# --- Prometheus server ---
 server:
   retention: 10d
-  # OpenShift assigns a random UID via SCC; leave user/group unset.
   securityContext:
     runAsUser: null
     runAsNonRoot: true
@@ -36,82 +44,59 @@ server:
     limits:
       cpu: 500m
       memory: 1Gi
-  # Scrape a bit less frequently than default to keep the footprint small.
   global:
     scrape_interval: 30s
     scrape_timeout: 10s
     evaluation_interval: 30s
   service:
     servicePort: 80
-  # No Prometheus-native alerting; Grafana owns alerts.
-  # (alertmanagers left empty by disabling the subchart below)
 
-# --- kube-state-metrics: the source of pod/deployment state metrics ---
-# This is what exposes kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"},
-# kube_pod_container_status_restarts_total, kube_pod_container_resource_limits, etc.
+# --- Disable everything that needs cluster-scoped RBAC or host access ---
 kube-state-metrics:
-  enabled: true
-  securityContext:
-    enabled: true
-    runAsUser: null
-    runAsGroup: null
-    fsGroup: null
-    runAsNonRoot: true
-  resources:
-    requests:
-      cpu: 20m
-      memory: 64Mi
-    limits:
-      cpu: 100m
-      memory: 256Mi
-  # Only collect the resource kinds we alert on — keeps cardinality/footprint low.
-  collectors:
-    - pods
-    - deployments
-    - replicasets
-    - statefulsets
-    - nodes
-
-# --- Components we do NOT need (keep the tools namespace light) ---
+  enabled: false          # deployed per-namespace instead (see values-kube-state-metrics.yaml)
 alertmanager:
   enabled: false          # Grafana handles alerting -> n8n
 prometheus-node-exporter:
-  enabled: false          # node-level metrics need host access / privileged SCC; not needed for pod-state alerts
+  enabled: false          # needs privileged host access
 prometheus-pushgateway:
   enabled: false
 
-# --- Scrape configuration ---
-# kube-state-metrics is auto-scraped by the chart's built-in job. Add the app
-# workloads' own /metrics (they carry prometheus.io/scrape annotations) so we
-# also get app-level metrics in dev/test/prod.
-extraScrapeConfigs: |
-  - job_name: 'common-notify-app-pods'
-    kubernetes_sd_configs:
-      - role: pod
-        namespaces:
-          names:
-            - f6bc3f-dev
-            - f6bc3f-test
-            - f6bc3f-prod
-    relabel_configs:
-      # Only pods that opt in with prometheus.io/scrape: "true"
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-        action: keep
-        regex: true
-      # Honour prometheus.io/path
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-      # Honour prometheus.io/port
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-        action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-        target_label: __address__
-      - source_labels: [__meta_kubernetes_namespace]
-        target_label: namespace
-      - source_labels: [__meta_kubernetes_pod_name]
-        target_label: pod
-      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
-        target_label: app
+# The chart's default server config includes kubernetes_sd_configs scrape jobs
+# that require cluster RBAC. Replace the whole scrape config with static targets
+# so the Prometheus server needs NO Kubernetes API access at all.
+serverFiles:
+  prometheus.yml:
+    global:
+      scrape_interval: 30s
+      scrape_timeout: 10s
+      evaluation_interval: 30s
+    scrape_configs:
+      # Prometheus scraping itself
+      - job_name: prometheus
+        static_configs:
+          - targets: ['localhost:9090']
+
+      # Per-namespace kube-state-metrics (pod/deployment state).
+      # Service name is "<release>-kube-state-metrics"; released as "ksm" in each
+      # app namespace, so the service DNS is ksm-kube-state-metrics.<ns>.svc:8080.
+      - job_name: kube-state-metrics
+        static_configs:
+          - targets: ['ksm-kube-state-metrics.f6bc3f-dev.svc.cluster.local:8080']
+            labels: { cluster_namespace: f6bc3f-dev }
+          - targets: ['ksm-kube-state-metrics.f6bc3f-test.svc.cluster.local:8080']
+            labels: { cluster_namespace: f6bc3f-test }
+          - targets: ['ksm-kube-state-metrics.f6bc3f-prod.svc.cluster.local:8080']
+            labels: { cluster_namespace: f6bc3f-prod }
+
+      # App /metrics (backend exposes /api/metrics on :3000). Static per-service
+      # DNS avoids pod service-discovery RBAC. Add per-PR targets as needed, or
+      # rely on kube-state-metrics for PR pod-state (no app metrics for PRs).
+      - job_name: common-notify-app
+        metrics_path: /api/metrics
+        static_configs:
+          - targets: ['common-notify-dev-backend.f6bc3f-dev.svc.cluster.local:80']
+            labels: { namespace: f6bc3f-dev, app: backend }
+          - targets: ['common-notify-test-backend.f6bc3f-test.svc.cluster.local:80']
+            labels: { namespace: f6bc3f-test, app: backend }
+          - targets: ['common-notify-prod-backend.f6bc3f-prod.svc.cluster.local:80']
+            labels: { namespace: f6bc3f-prod, app: backend }


### PR DESCRIPTION
# Description

Fixes a silent-alerting gap and the Redis crash loop that exposed it.

**Background:** The Redis pods (and the dev backend they took down with them) crash-looped for 3+ days with hundreds of restarts and **no alert fired**. Root cause of the silence: the monitoring stack was **Loki-only (logs)**. Kubernetes pod state (CrashLoopBackOff, OOMKilled, restarts) is a *metric*, not a log line, so no rule could see it — and there was no Prometheus deployed to collect metrics at all (the app pods carry `prometheus.io/scrape` annotations, but nothing was scraping them).

This PR does two things:

**1. Fix the Redis crash loop (durably).** The deployed Redis ran a **192Mi** memory limit while carrying the Bull/BullMQ job queue (~67k keys) plus the RediSearch + ReJSON modules — well over 192Mi, so the kernel OOMKilled it on every startup/resync. `charts/redis/values.yml`:
- master + replica memory: **512Mi→1Gi** limit, 128Mi→512Mi request
- add **`maxmemory 768mb` + `maxmemory-policy noeviction`** so Redis caps itself below the container limit instead of being OOMKilled. `noeviction` is correct here — this backs a **durable job queue**, not a cache; reject writes when full rather than silently drop queued notifications.

**2. Add metric-based pod-state / memory alerting.** Deploy a small in-namespace Prometheus + kube-state-metrics (no Thanos, no object storage) and Grafana-managed alert rules routed to the existing n8n contact point:
- CrashLoopBackOff, PodRestartsHigh, PodNotReady, DeploymentReplicasMismatch, ContainerOOMKilled (from kube-state-metrics)
- ContainerMemoryHigh/Critical, CPUThrottlingHigh (need cAdvisor — see caveat)

### RBAC-safe design (BC Gov Silver constraints)

Tenants cannot create cluster-scoped RBAC, and the pipeline SA cannot create RBAC cross-namespace. So:
- **kube-state-metrics is deployed per app namespace** (dev/test/prod) using each namespace's own token (like the grafana-agent jobs) — namespaced RBAC only.
- **Central Prometheus** (tools) uses **static-DNS scraping** (`static_configs`), not `kubernetes_sd_configs`, so it needs **no Kubernetes API access** at all. `rbac.create: false`.
- NetworkPolicies allow tools→KSM:8080 (per app ns) and Grafana→Prometheus:9090.
- Sized to the tools namespace: Prometheus on `netapp-block-standard`, 5Gi, 7d retention (the tools namespace has a 10Gi aggregate storage quota, 5Gi already used by Loki).

### ⚠️ cAdvisor caveat (documented in `infra-alert-rules.yaml`)

Container memory-usage-% and CPU-throttling rules use `container_memory_working_set_bytes` / cgroup metrics from **cAdvisor/kubelet**, which a namespaced Prometheus is not permitted to scrape (needs cluster RBAC that Silver tenants can't get). Those two rule families show `nodata` — **`ContainerOOMKilled` (from kube-state-metrics) is the reliable memory signal** and works.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual tests (description below)
- [x] No new unit tests are required (infra/config only)

**Verified live on the Silver cluster:**
- Redis: master + replica `1/1 Running`, 0 restarts at 1Gi; crash loop cleared.
- kube-state-metrics: `1/1 Running` in dev/test/prod, namespaced RBAC.
- Prometheus: `2/2 Running`; all three KSM targets `UP`; `kube_pod_container_status_restarts_total` and CrashLoop metrics queryable.
- Grafana: all 8 infra rules loaded and evaluating; pod-state + OOMKilled rules `health=ok`.
- **`PodCrashLoopBackOff` fired on a real live crash loop** and reached the notifier — the exact alert that was missing.
- Fixed an n8n webhook template bug (`{{ .StartsAt | since }}` → `.StartsAt`; `since` is undefined in this Grafana version and blocked all delivery).

**First pipeline run to watch:** the KSM/Prometheus/Grafana pieces were deployed manually and verified. Their first run through `deploy-monitoring.yml` is the real test of the per-namespace KSM token-based RBAC and the NetworkPolicy applies (both are wired into the jobs).

## Notes for reviewers

- Merging this is what makes the **Redis fix durable** — `main` still carries 192Mi, so every deploy currently re-triggers the crash loop (it regressed twice during this work). The live `oc` patches are temporary.
- No app/runtime code changes — only `charts/redis/values.yml`, `monitoring/grafana-stack/**`, and `.github/workflows/deploy-monitoring.yml`.

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] My changes generate no new warnings
- [x] I have commented my code / config where non-obvious (RBAC, quota, cAdvisor caveat)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-202.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-202.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)