### PR TITLE
fix(redis): un-nest chart values and pin image by digest (makes the memory fix actually apply)

### DIFF
--- a/charts/redis/values-dev.yml
+++ b/charts/redis/values-dev.yml
@@ -2,13 +2,12 @@
 # - Reduced replicas due to storage constraints (40Gi quota)
 # - Disabled PodDisruptionBudget (not needed in dev)
 # - Disabled Sentinel (not needed with only 1 replica)
-redis:
-  replica:
-    replicaCount: 1
-    podDisruptionBudget:
-      enabled: false
-  sentinel:
+replica:
+  replicaCount: 1
+  podDisruptionBudget:
     enabled: false
-  master:
-    podDisruptionBudget:
-      enabled: false
+sentinel:
+  enabled: false
+master:
+  podDisruptionBudget:
+    enabled: false

--- a/charts/redis/values-prod.yml
+++ b/charts/redis/values-prod.yml
@@ -1,4 +1,3 @@
 # Production environment overrides
-redis:
-  replica:
-    replicaCount: 2
+replica:
+  replicaCount: 2

--- a/charts/redis/values.yml
+++ b/charts/redis/values.yml
@@ -9,7 +9,13 @@ global:
     # the chart's image-verification guard. Allow it explicitly.
     allowInsecureImages: true
 auth:
-  enabled: false  # Disabled per BC Gov pattern
+  # Keep auth ENABLED. Before un-nesting, this whole block was ignored and the
+  # chart default (auth ON) applied, so a `common-notify-redis` secret with a
+  # `redis-password` key was always created. The backend REQUIRES that secret
+  # (REDIS_PASSWORD secretKeyRef, non-optional — charts/app/.../backend/deployment.yaml).
+  # Disabling auth removes the secret and breaks the backend
+  # (CreateContainerConfigError: secret "common-notify-redis" not found).
+  enabled: true
 image:
   # Pin by DIGEST, not a floating tag. Redis previously ran on :latest (Bitnami
   # deleted the old numbered tags from Docker Hub, so this chart's config had been

--- a/charts/redis/values.yml
+++ b/charts/redis/values.yml
@@ -80,7 +80,13 @@ replica:
       cpu: 500m
       memory: 1Gi
 sentinel:
-  enabled: true
+  # Sentinel is DISABLED. Every environment actually runs the replication
+  # architecture (separate redis-master + redis-replicas StatefulSets), and the
+  # app connects to `common-notify-redis-master`. This value used to say `true`,
+  # but the whole redis: block was nested and ignored, so Sentinel never ran.
+  # Enabling it now would switch to the `redis-node` topology, remove the
+  # `-redis-master` service the backend targets, and break the app. Keep it off.
+  enabled: false
   quorum: 1
   podSecurityContext:
     enabled: true

--- a/charts/redis/values.yml
+++ b/charts/redis/values.yml
@@ -1,128 +1,139 @@
 # Redis configuration for job queues and caching
 # Based on BC Gov OpenShift best practices - using Sentinel architecture
 # Storage quota freed - ready for automated deployment
-redis:
-  enabled: true
-  architecture: replication
-  global:
+architecture: replication
+global:
+  storageClass: netapp-block-standard
+  security:
+    # The pinned tag below differs from the chart's default image, which trips
+    # the chart's image-verification guard. Allow it explicitly.
+    allowInsecureImages: true
+auth:
+  enabled: false  # Disabled per BC Gov pattern
+image:
+  # Pin by DIGEST, not a floating tag. Redis previously ran on :latest (Bitnami
+  # deleted the old numbered tags from Docker Hub, so this chart's config had been
+  # silently falling back to :latest). A floating tag let the on-disk RDB format
+  # upgrade underneath the running server, corrupting the AOF and causing
+  # "Can't handle RDB format version 15" crash loops. This digest is the image
+  # PROD is currently running (verified pullable); pinning it makes the version
+  # stable across restarts and environments.
+  registry: registry-1.docker.io
+  repository: bitnami/redis
+  tag: latest
+  digest: "sha256:23289a4f4765da46419590fb80d8803363b07e5783ef45396ff85c641db81a0e"
+master:
+  podSecurityContext:
+    enabled: true
+    fsGroup: null
+    runAsUser: null
+  containerSecurityContext:
+    enabled: true
+    runAsUser: null
+    runAsNonRoot: false
+  persistence:
+    enabled: true
+    size: 1Gi
     storageClass: netapp-block-standard
-  auth:
-    enabled: false  # Disabled per BC Gov pattern
+  # Sized for the Bull/BullMQ job queue (~67k keys) plus RediSearch + ReJSON
+  # modules and replication resync headroom. 512Mi OOM-looped in dev (CCP: redis
+  # OOMKilled x300+). maxmemory (in commonConfiguration) caps usage below the limit.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+replica:
+  shareProcessNamespace: true
+  replicaCount: 2
+  podSecurityContext:
+    enabled: true
+    fsGroup: null
+    runAsUser: null
+  containerSecurityContext:
+    enabled: true
+    runAsUser: null
+    runAsNonRoot: false
+  persistentVolumeClaimRetentionPolicy:
+    enabled: true
+    whenDeleted: Delete
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    storageClass: netapp-block-standard
+  # Match master sizing — replicas load the full dataset and perform full resync,
+  # which is when memory peaks. 512Mi OOM-looped in dev.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+sentinel:
+  enabled: true
+  quorum: 1
+  podSecurityContext:
+    enabled: true
+    fsGroup: null
+    runAsUser: null
+  containerSecurityContext:
+    enabled: true
+    runAsUser: null
+    runAsNonRoot: false
   image:
-    registry: docker.io
-    tag: "7.4.1-debian-12-r1"  # Pinned stable tag (avoid latest)
-  master:
-    podSecurityContext:
-      enabled: true
-      fsGroup: null
-      runAsUser: null
-    containerSecurityContext:
-      enabled: true
-      runAsUser: null
-      runAsNonRoot: false
-    persistence:
-      enabled: true
-      size: 1Gi
-      storageClass: netapp-block-standard
-    # Sized for the Bull/BullMQ job queue (~67k keys) plus RediSearch + ReJSON
-    # modules and replication resync headroom. 512Mi OOM-looped in dev (CCP: redis
-    # OOMKilled x300+). maxmemory (in commonConfiguration) caps usage below the limit.
-    resources:
-      requests:
-        cpu: 100m
-        memory: 512Mi
-      limits:
-        cpu: 500m
-        memory: 1Gi
-  replica:
-    shareProcessNamespace: true
-    replicaCount: 2
-    podSecurityContext:
-      enabled: true
-      fsGroup: null
-      runAsUser: null
-    containerSecurityContext:
-      enabled: true
-      runAsUser: null
-      runAsNonRoot: false
-    persistentVolumeClaimRetentionPolicy:
-      enabled: true
-      whenDeleted: Delete
-    persistence:
-      enabled: true
-      accessMode: ReadWriteOnce
-      size: 1Gi
-      storageClass: netapp-block-standard
-    # Match master sizing — replicas load the full dataset and perform full resync,
-    # which is when memory peaks. 512Mi OOM-looped in dev.
-    resources:
-      requests:
-        cpu: 100m
-        memory: 512Mi
-      limits:
-        cpu: 500m
-        memory: 1Gi
-  sentinel:
+    registry: artifacts.developer.gov.bc.ca/docker-remote
+  persistence:
     enabled: true
-    quorum: 1
-    podSecurityContext:
-      enabled: true
-      fsGroup: null
-      runAsUser: null
-    containerSecurityContext:
-      enabled: true
-      runAsUser: null
-      runAsNonRoot: false
-    image:
-      registry: artifacts.developer.gov.bc.ca/docker-remote
-    persistence:
-      enabled: true
-      accessMode: ReadWriteOnce
-      size: 1Gi
-      storageClass: netapp-block-standard
-    persistentVolumeClaimRetentionPolicy:
-      enabled: true
-      whenScaled: Delete
-      whenDeleted: Delete
-    resources:
-      requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 200m
-        memory: 256Mi
-  # AOF persistence configuration
-  commonConfiguration: |-
-    # Enable AOF persistence
-    appendonly yes
-    appendfsync everysec
-    appendfilename "appendonly.aof"
-    # Disable RDB persistence
-    save ""
-    # Cap Redis memory BELOW the 1Gi container limit so Redis manages memory itself
-    # instead of being OOMKilled by the kernel (which caused a 300+ restart crash loop).
-    # Headroom (1Gi - 768mb) covers RediSearch/ReJSON module overhead and resync buffers.
-    maxmemory 768mb
-    # This Redis backs a durable Bull/BullMQ job queue (ingestion/email/sms), NOT a
-    # disposable cache. noeviction => reject new writes when full rather than silently
-    # dropping queued jobs. If writes start failing, raise the limit — do not switch to LRU.
-    maxmemory-policy noeviction
-  metrics:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    storageClass: netapp-block-standard
+  persistentVolumeClaimRetentionPolicy:
     enabled: true
-    podSecurityContext:
-      enabled: true
-      fsGroup: null
-      runAsUser: null
-    containerSecurityContext:
-      enabled: true
-      runAsUser: null
-      runAsNonRoot: false
-    image:
-      registry: artifacts.developer.gov.bc.ca/docker-remote
-    resources:
-      requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 200m
-        memory: 256Mi
+    whenScaled: Delete
+    whenDeleted: Delete
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+# AOF persistence configuration
+commonConfiguration: |-
+  # Enable AOF persistence
+  appendonly yes
+  appendfsync everysec
+  appendfilename "appendonly.aof"
+  # Disable RDB persistence
+  save ""
+  # Cap Redis memory BELOW the 1Gi container limit so Redis manages memory itself
+  # instead of being OOMKilled by the kernel (which caused a 300+ restart crash loop).
+  # Headroom (1Gi - 768mb) covers RediSearch/ReJSON module overhead and resync buffers.
+  maxmemory 768mb
+  # This Redis backs a durable Bull/BullMQ job queue (ingestion/email/sms), NOT a
+  # disposable cache. noeviction => reject new writes when full rather than silently
+  # dropping queued jobs. If writes start failing, raise the limit — do not switch to LRU.
+  maxmemory-policy noeviction
+metrics:
+  enabled: true
+  podSecurityContext:
+    enabled: true
+    fsGroup: null
+    runAsUser: null
+  containerSecurityContext:
+    enabled: true
+    runAsUser: null
+    runAsNonRoot: false
+  image:
+    registry: artifacts.developer.gov.bc.ca/docker-remote
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
# Description

Fixes the reason the Redis 1Gi memory fix (#202) never actually took effect, and the root cause of the recurring RDB-corruption crash loops.

## Root cause
`charts/redis/values.yml` (and `values-dev.yml`, `values-prod.yml`) nested **all** configuration under a top-level `redis:` key. But the pipeline deploys the **`bitnami/redis` chart directly** (not as a subchart), so Helm ignored the entire block. Every environment has been running **pure Bitnami chart defaults**:
- `resourcesPreset: nano` → **192Mi** (not the intended limits)
- image **`:latest`** (not the intended pinned tag)

Consequences:
- The 1Gi memory fix from #202 **never applied** — the deployed StatefulSet stayed at 192Mi and kept OOM-crash-looping.
- Redis floated on **`:latest`**, which silently upgraded the on-disk RDB format under the running server and corrupted the AOF (`Can't handle RDB format version 15`), causing repeated crash loops even after memory was patched by hand.

## Changes
- **Un-nest** all three value files (remove the top-level `redis:` wrapper) so the config actually applies to the direct chart deploy. Drop the subchart-only `enabled: true`.
- **Pin the image by digest** instead of a floating `:latest`. The tag previously configured (`7.4.1-debian-12-r1`) no longer exists on Docker Hub (Bitnami removed old numbered tags), so a tag pin fails to pull. The digest used is the exact image **PROD currently runs** — known-pullable, same Redis version, just no longer floating.
- Add `global.security.allowInsecureImages: true` (required by the chart once a non-default image is actually applied).

Net effect once deployed: memory `1Gi` + `maxmemory 768mb` / `noeviction` take effect, and the image is stable across restarts (no more silent RDB-format upgrades).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (rollout note below)

## How Has This Been Tested?
- [x] Manual tests (below)

**Verified live in DEV:** after deploying the un-nested + digest-pinned config, `redis-master` and `redis-replicas` are `2/2 Running`, 0 restarts, `mem=1Gi`, image pinned to the digest.

## ⚠️ Rollout note — TEST/PROD not changed by this PR live
Applying this to a **running** StatefulSet requires a **delete + recreate** (it changes immutable spec fields — storage class / PVC template — which Helm cannot patch in place). On PROD that means a brief Redis outage while the master reloads its live queue.

**DEV was applied and verified live. TEST and PROD should be rolled out as a deliberate, reviewed maintenance action** (test first, then prod in a low-traffic window), not via an unattended pipeline deploy. When merged, the merge pipeline's redis diff-trigger may attempt an in-place upgrade that will fail on the immutable fields — the recreate needs to be done intentionally.

## Checklist
- [x] I have read the CONTRIBUTING doc
- [x] I have commented the config where non-obvious (why un-nested, why digest-pinned)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://common-notify-204.apps.silver.devops.gov.bc.ca)
- [Backend](https://common-notify-204.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/common-notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/common-notify/actions/workflows/merge.yml)